### PR TITLE
Use preTranslate for absolute pans

### DIFF
--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.java
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.java
@@ -916,8 +916,8 @@ public final class ZoomEngine implements ViewTreeObserver.OnGlobalLayoutListener
         newZoom = ensureScaleBounds(newZoom, allowOverPinch);
         float scaleFactor = newZoom / mZoom;
         // mMatrix.postScale(scaleFactor, scaleFactor, mViewWidth / 2f, mViewHeight / 2f);
-        // mMatrix.postScale(scaleFactor, scaleFactor, mContentRect.left, mContentRect.top);
-        mMatrix.postScale(scaleFactor, scaleFactor, mContentRect.width(), mContentRect.height());
+        mMatrix.postScale(scaleFactor, scaleFactor, mContentRect.left, mContentRect.top);
+        // mMatrix.postScale(scaleFactor, scaleFactor, mContentRect.width(), mContentRect.height());
         mMatrix.mapRect(mContentRect, mContentBaseRect);
         mZoom = newZoom;
 

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.java
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.java
@@ -292,12 +292,12 @@ public final class ZoomEngine implements ViewTreeObserver.OnGlobalLayoutListener
             // Base zoom makes no sense anymore. We must recompute it.
             // We must also compute a new zoom value so that real zoom (that is, the matrix scale)
             // is kept the same as before. (So, no matrix updates here).
-            LOG.i("init:", "was initialized. Trying to keep real zoom to", getRealZoom());
-            LOG.i("init:", "keepRealZoom: oldBaseZoom:", mBaseZoom, "oldZoom:" + mZoom);
+            LOG.i("init:", "wasAlready:", "Trying to keep real zoom to", getRealZoom());
+            LOG.i("init:", "wasAlready:", "oldBaseZoom:", mBaseZoom, "oldZoom:" + mZoom);
             @RealZoom float realZoom = getRealZoom();
             mBaseZoom = computeBaseZoom();
             mZoom = realZoom / mBaseZoom;
-            LOG.i("init:", "keepRealZoom: newBaseZoom:", mBaseZoom, "newZoom:", mZoom);
+            LOG.i("init:", "wasAlready: newBaseZoom:", mBaseZoom, "newZoom:", mZoom);
 
             // Now sync the content rect with the current matrix since we are trying to keep it.
             // This is to have consistent values for other calls here.
@@ -306,7 +306,7 @@ public final class ZoomEngine implements ViewTreeObserver.OnGlobalLayoutListener
             // If the new zoom value is invalid, though, we must bring it to the valid place.
             // This is a possible matrix update.
             @Zoom float newZoom = ensureScaleBounds(mZoom, false);
-            LOG.i("init:", "ensureScaleBounds:", "we need a correction of", (newZoom - mZoom));
+            LOG.i("init:", "wasAlready:", "scaleBounds:", "we need a zoom correction of", (newZoom - mZoom));
             if (newZoom != mZoom) applyZoom(newZoom, false);
 
             // If there was any, pan should be kept. I think there's nothing to do here:
@@ -322,8 +322,14 @@ public final class ZoomEngine implements ViewTreeObserver.OnGlobalLayoutListener
             mMatrix.setScale(mBaseZoom, mBaseZoom);
             mMatrix.mapRect(mContentRect, mContentBaseRect);
             mZoom = 1f;
+            LOG.i("init:", "fromScratch:", "newBaseZoom:", mBaseZoom, "newZoom:", mZoom);
 
-            LOG.i("init:", "was not initialized.", "Setting baseZoom:", mBaseZoom, "zoom:", mZoom);
+            @Zoom float newZoom = ensureScaleBounds(mZoom, false);
+            LOG.i("init:", "fromScratch:", "scaleBounds:", "we need a zoom correction of", (newZoom - mZoom));
+            if (newZoom != mZoom) {
+                // Zoom only would zoom in the center of the content. Keep it left.
+                applyZoomAndAbsolutePan(newZoom, 0, 0, false);
+            }
 
             ensureCurrentTranslationBounds(false);
             dispatchOnMatrix();
@@ -938,7 +944,6 @@ public final class ZoomEngine implements ViewTreeObserver.OnGlobalLayoutListener
      * Applies the given zoom value, meant as a {@link Zoom} value
      * (so not a {@link RealZoom}).
      * The zoom is applied so that the center point is kept in its place
-     * TODO: probably
      *
      * @param newZoom the new zoom value
      * @param allowOverPinch whether to overpinch

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.java
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.java
@@ -591,8 +591,8 @@ public final class ZoomEngine implements ViewTreeObserver.OnGlobalLayoutListener
                 // Allow overScroll. Will be reset in onScrollEnd().
                 distanceX = -distanceX;
                 distanceY = -distanceY;
-                applyZoomAndAbsolutePan(getZoom(), getPanX() + distanceX,
-                        getPanY() + distanceY, true);
+                applyScaledPan(distanceX, distanceY, true);
+                // applyZoomAndAbsolutePan(getZoom(), getPanX() + distanceX, getPanY() + distanceY, true);
                 return true;
             }
             return false;
@@ -962,7 +962,6 @@ public final class ZoomEngine implements ViewTreeObserver.OnGlobalLayoutListener
      * Absolute panning is achieved through {@link Matrix#preTranslate(float, float)},
      * which works in the original coordinate system.
      *
-     * TODO: probably
      * @param newZoom the new zoom value
      * @param x the final left absolute pan
      * @param y the final top absolute pan
@@ -1059,7 +1058,7 @@ public final class ZoomEngine implements ViewTreeObserver.OnGlobalLayoutListener
         return fix != 0;
     }
 
-    private boolean startFling(@AbsolutePan int velocityX, @AbsolutePan int velocityY) {
+    private boolean startFling(@ScaledPan int velocityX, @ScaledPan int velocityY) {
         if (!setState(FLINGING)) return false;
 
         // Using actual pan values for the scroller.
@@ -1078,11 +1077,11 @@ public final class ZoomEngine implements ViewTreeObserver.OnGlobalLayoutListener
         if (!go) return false;
 
         @ScaledPan int overScroll = mOverScrollable ? getCurrentOverScroll() : 0;
+        LOG.i("startFling", "velocityX:", velocityX, "velocityY:", velocityY);
         LOG.i("startFling", "flingX:", "min:", minX, "max:", maxX, "start:", startX, "overScroll:", overScroll);
         LOG.i("startFling", "flingY:", "min:", minY, "max:", maxY, "start:", startY, "overScroll:", overScroll);
         mFlingScroller.fling(startX, startY,
-                (int) resolvePan(velocityX),
-                (int) resolvePan(velocityY),
+                velocityX, velocityY,
                 minX, maxX, minY, maxY,
                 overScroll, overScroll);
 


### PR DESCRIPTION
Using `preTranslate` for absolute pans, instead of converting to scaled pan and then using `postTranslate` . This should make APIs much more precise.