### PR TITLE
Base transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Flexible utilities to control and animate zoom and translation of Views and much
 programmatically or through touch events.
 
 ```groovy
-compile 'com.otaliastudios:zoomlayout:1.1.1'
+compile 'com.otaliastudios:zoomlayout:1.2.0'
 ```
 
 <p>

--- a/README.md
+++ b/README.md
@@ -134,19 +134,43 @@ There is no strict limit over what you can do with a `Matrix`,
 
 ### Zoom
 
-The engine currently applies, by default, a "center inside" policy when it is initialized.
-This means that the content (whatever it is) is scaled down (or up) to fit the parent view bounds,
-without cropping.
+#### Transformations
 
-This base zoom makes the difference between **zoom** and **realZoom**. Table should be descriptive enough:
+When the engine becomes aware of the content size, it will apply a base transformation to the content
+that can be controlled through `setTransformation(int, int)` or `app:transformation` and `app:transformationGravity`.
+It is applied only once, and defines the starting viewport over our content.
+
+|Transformation|Description|
+|`centerInside`|The content is scaled down or up so that it fits completely inside the view bounds.|
+|`centerCrop`|The content is scaled down or up so that its smaller side fits exactly inside the view bounds. The larger side will be cropped.|
+|`none`|No transformation is applied.|
+
+If, after applying the transformation (and any minZoom / maxZoom constraint), the content is partially
+cropped along some dimension, the engine will also apply a translation according to the given transformation gravity.
+
+|Transformation Gravity|Description|
+|`top`|If the content is taller than the view, translate it so that we see the top part.|
+|`bottom`|If the content is taller than the view, translate it so that we see the bottom part.|
+|`left`|If the content is wider than the view, translate it so that we see the left part.|
+|`right`|If the content is wider than the view, translate it so that we see the right part.|
+
+#### Zoom Types
+
+The base transformation makes the difference between **zoom** and **realZoom**. Since we have silently applied
+a base zoom to the content, we must introduce two separate types:
 
 |Zoom type|Value|Description|
 |---------|-----|-----------|
-|Zoom|`ZoomEngine.TYPE_ZOOM`|The scale value after the initial, center-inside base zoom was applied. `zoom == 1` means that the content fits the screen perfectly.|
-|Real zoom|`ZoomEngine.TYPE_REAL_ZOOM`|The actual scale value, including the initial base zoom. `realZoom == 1` means that the 1 inch of the content fits 1 inch of the screen.|
+|Zoom|`TYPE_ZOOM`|The scale value after the initial transformation. `zoom == 1` means that the content was untouched after the transformation.|
+|Real zoom|`TYPE_REAL_ZOOM`|The actual scale value, including the initial transformation. `realZoom == 1` means that the 1 inch of the content fits 1 inch of the screen.|
+
+To make things clearer, when transformation is `none`, the zoom and the real zoom will be identical.
+The distinction is very useful when it comes to imposing min and max constraints to our zoom value.
+
+#### APIs
 
 Some of the zoom APIs will let you pass an integer (either `TYPE_ZOOM` or `TYPE_REAL_ZOOM`)
-to define the zoom you are referencing to. Depending on the context, imposing restrictions on one type
+to define the zoom type you are referencing to. Depending on the context, imposing restrictions on one type
 will make more sense than the other - e. g., in a PDF viewer, you might want to cap real zoom at `1`.
 
 |API|Description|Default value|

--- a/app/src/main/java/com/otaliastudios/zoom/demo/ColorGridView.java
+++ b/app/src/main/java/com/otaliastudios/zoom/demo/ColorGridView.java
@@ -20,7 +20,7 @@ import java.util.Random;
 
 public class ColorGridView extends GridLayout {
 
-    private final static int ROWS = 20;
+    private final static int ROWS = 50;
     private final static int COLS = 20;
     private final static Random R = new Random();
 

--- a/app/src/main/java/com/otaliastudios/zoom/demo/ColorGridView.java
+++ b/app/src/main/java/com/otaliastudios/zoom/demo/ColorGridView.java
@@ -20,7 +20,7 @@ import java.util.Random;
 
 public class ColorGridView extends GridLayout {
 
-    private final static int ROWS = 50;
+    private final static int ROWS = 20;
     private final static int COLS = 20;
     private final static Random R = new Random();
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.jfrog.bintray'
 // Required by bintray
 // archivesBaseName is required if artifactId is different from gradle module name
 // or you can add baseName to each archive task (sources, javadoc, aar)
-version = '1.1.1'
+version = '1.2.0'
 group = 'com.otaliastudios'
 archivesBaseName = 'zoomlayout'
 

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomApi.java
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomApi.java
@@ -43,7 +43,7 @@ public interface ZoomApi {
      * @see #getZoom()
      * @see #getRealZoom()
      */
-    public static final int TYPE_ZOOM = 0;
+    int TYPE_ZOOM = 0;
 
     /**
      * Flag for zoom constraints and settings.
@@ -53,11 +53,35 @@ public interface ZoomApi {
      * @see #getZoom()
      * @see #getRealZoom()
      */
-    public static final int TYPE_REAL_ZOOM = 1;
+    int TYPE_REAL_ZOOM = 1;
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({TYPE_ZOOM, TYPE_REAL_ZOOM})
-    public @interface ZoomType {}
+    @interface ZoomType {}
+
+    /**
+     * Constant for {@link #setTransformation(int, int)}.
+     * The content will be zoomed so that it fits completely inside the container.
+     */
+    int TRANSFORMATION_CENTER_INSIDE = 0;
+
+    /**
+     * Constant for {@link #setTransformation(int, int)}.
+     * The content will be zoomed so that its smaller side fits exactly inside the container.
+     * The larger side will be partially cropped.
+     */
+    int TRANSFORMATION_CENTER_CROP = 1;
+
+    /**
+     * Constant for {@link #setTransformation(int, int)}.
+     * No transformation will be applied, which means that both {@link #getZoom()} and
+     * {@link #getRealZoom()} will return the same value.
+     */
+    int TRANSFORMATION_NONE = 2;
+
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({TRANSFORMATION_CENTER_INSIDE, TRANSFORMATION_CENTER_CROP, TRANSFORMATION_NONE})
+    @interface Transformation {}
 
     /**
      * Controls whether the content should be over-scrollable horizontally.
@@ -85,6 +109,16 @@ public interface ZoomApi {
      * @param overPinchable whether to allow over pinching
      */
     void setOverPinchable(boolean overPinchable);
+
+    /**
+     * Sets the base transformation to be applied to the content.
+     * Defaults to {@link #TRANSFORMATION_CENTER_INSIDE} with {@link android.view.Gravity#CENTER},
+     * which means that the content will be zoomed so that it fits completely inside the container.
+     *
+     * @param transformation the transformation type
+     * @param gravity the transformation gravity. Might be ignored for some transformations
+     */
+    void setTransformation(@Transformation int transformation, int gravity);
 
     /**
      * A low level API that can animate both zoom and pan at the same time.

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.java
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.java
@@ -30,8 +30,11 @@ import java.util.Random;
  * - Notify the helper of the content size, using {@link #setContentSize(RectF)}
  * - Pass touch events to {@link #onInterceptTouchEvent(MotionEvent)} and {@link #onTouchEvent(MotionEvent)}
  *
- * This class will try to keep the content centered. It also starts with a "center inside" policy
- * that will apply a base zoom to the content, so that it fits inside the view container.
+ * This class will apply a base transformation to the content, see {@link #setTransformation(int, int)},
+ * so that it is laid out initially as we wish.
+ *
+ * When the scaling makes the content smaller than our viewport, the engine will always try
+ * to keep the content centered.
  */
 public final class ZoomEngine implements ViewTreeObserver.OnGlobalLayoutListener, ZoomApi {
 
@@ -828,7 +831,7 @@ public final class ZoomEngine implements ViewTreeObserver.OnGlobalLayoutListener
      * {@link #zoomTo(float, boolean)} or {@link #zoomBy(float, boolean)}.
      *
      * This can be different than the actual scale you get in the matrix, because at startup
-     * we apply a base zoom to respect the "center inside" policy.
+     * we apply a base transformation, see {@link #setTransformation(int, int)}.
      * All zoom calls, including min zoom and max zoom, refer to this axis, where zoom is set to 1
      * right after the initial transformation.
      *
@@ -842,10 +845,10 @@ public final class ZoomEngine implements ViewTreeObserver.OnGlobalLayoutListener
     }
 
     /**
-     * Gets the current zoom value, including the base zoom that was eventually applied when
-     * initializing to respect the "center inside" policy. This will match the scaleX - scaleY
-     * values you get into the {@link Matrix}, and is the actual scale value of the content
-     * from its original size.
+     * Gets the current zoom value, including the base zoom that was eventually applied during
+     * the starting transformation, see {@link #setTransformation(int, int)}.
+     * This value will match the scaleX - scaleY values you get into the {@link Matrix},
+     * and is the actual scale value of the content from its original size.
      *
      * @return the real zoom
      */

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomImageView.java
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomImageView.java
@@ -10,6 +10,7 @@ import android.support.annotation.AttrRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
+import android.view.Gravity;
 import android.view.MotionEvent;
 import android.widget.ImageView;
 
@@ -40,31 +41,24 @@ public class ZoomImageView extends ImageView implements ZoomEngine.Listener, Zoo
         super(context, attrs, defStyleAttr);
 
         TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.ZoomEngine, defStyleAttr, 0);
-        // Support deprecated overScrollable
-        boolean overScrollHorizontal, overScrollVertical;
-        if (a.hasValue(R.styleable.ZoomEngine_overScrollable)) {
-            overScrollHorizontal = a.getBoolean(R.styleable.ZoomEngine_overScrollable, true);
-            overScrollVertical = a.getBoolean(R.styleable.ZoomEngine_overScrollable, true);
-        } else {
-            overScrollHorizontal = a.getBoolean(R.styleable.ZoomEngine_overScrollHorizontal, true);
-            overScrollVertical = a.getBoolean(R.styleable.ZoomEngine_overScrollVertical, true);
-        }
+        boolean overScrollHorizontal = a.getBoolean(R.styleable.ZoomEngine_overScrollHorizontal, true);
+        boolean overScrollVertical = a.getBoolean(R.styleable.ZoomEngine_overScrollVertical, true);
         boolean overPinchable = a.getBoolean(R.styleable.ZoomEngine_overPinchable, true);
         float minZoom = a.getFloat(R.styleable.ZoomEngine_minZoom, -1);
         float maxZoom = a.getFloat(R.styleable.ZoomEngine_maxZoom, -1);
-        @ZoomEngine.ZoomType int minZoomMode = a.getInteger(
-                R.styleable.ZoomEngine_minZoomType, ZoomEngine.TYPE_ZOOM);
-        @ZoomEngine.ZoomType int maxZoomMode = a.getInteger(
-                R.styleable.ZoomEngine_maxZoomType, ZoomEngine.TYPE_ZOOM);
-
+        @ZoomType int minZoomMode = a.getInteger(R.styleable.ZoomEngine_minZoomType, TYPE_ZOOM);
+        @ZoomType int maxZoomMode = a.getInteger(R.styleable.ZoomEngine_maxZoomType, TYPE_ZOOM);
+        int transformation = a.getInteger(R.styleable.ZoomEngine_transformation, TRANSFORMATION_CENTER_INSIDE);
+        int transformationGravity = a.getInt(R.styleable.ZoomEngine_transformationGravity, Gravity.CENTER);
         a.recycle();
 
         mEngine = new ZoomEngine(context, this, this);
-        mEngine.setOverScrollHorizontal(overScrollHorizontal);
-        mEngine.setOverScrollVertical(overScrollVertical);
-        mEngine.setOverPinchable(overPinchable);
-        if (minZoom > -1) mEngine.setMinZoom(minZoom, minZoomMode);
-        if (maxZoom > -1) mEngine.setMaxZoom(maxZoom, maxZoomMode);
+        setTransformation(transformation, transformationGravity);
+        setOverScrollHorizontal(overScrollHorizontal);
+        setOverScrollVertical(overScrollVertical);
+        setOverPinchable(overPinchable);
+        if (minZoom > -1) setMinZoom(minZoom, minZoomMode);
+        if (maxZoom > -1) setMaxZoom(maxZoom, maxZoomMode);
 
         setImageMatrix(mMatrix);
         setScaleType(ScaleType.MATRIX);
@@ -153,6 +147,19 @@ public class ZoomImageView extends ImageView implements ZoomEngine.Listener, Zoo
     @Override
     public void setOverPinchable(boolean overPinchable) {
         getEngine().setOverPinchable(overPinchable);
+    }
+
+    /**
+     * Sets the base transformation to be applied to the content.
+     * Defaults to {@link #TRANSFORMATION_CENTER_INSIDE} with {@link Gravity#CENTER},
+     * which means that the content will be zoomed so that it fits completely inside the container.
+     *
+     * @param transformation the transformation type
+     * @param gravity        the transformation gravity. Might be ignored for some transformations
+     */
+    @Override
+    public void setTransformation(int transformation, int gravity) {
+        getEngine().setTransformation(transformation, gravity);
     }
 
     /**

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomLayout.java
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomLayout.java
@@ -9,6 +9,7 @@ import android.support.annotation.AttrRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
+import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -51,32 +52,27 @@ public class ZoomLayout extends FrameLayout implements ZoomEngine.Listener, Zoom
 
     public ZoomLayout(@NonNull Context context, @Nullable AttributeSet attrs, @AttrRes int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+
         TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.ZoomEngine, defStyleAttr, 0);
-        // Support deprecated overScrollable
-        boolean overScrollHorizontal, overScrollVertical;
-        if (a.hasValue(R.styleable.ZoomEngine_overScrollable)) {
-            overScrollHorizontal = a.getBoolean(R.styleable.ZoomEngine_overScrollable, true);
-            overScrollVertical = a.getBoolean(R.styleable.ZoomEngine_overScrollable, true);
-        } else {
-            overScrollHorizontal = a.getBoolean(R.styleable.ZoomEngine_overScrollHorizontal, true);
-            overScrollVertical = a.getBoolean(R.styleable.ZoomEngine_overScrollVertical, true);
-        }
+        boolean overScrollHorizontal = a.getBoolean(R.styleable.ZoomEngine_overScrollHorizontal, true);
+        boolean overScrollVertical = a.getBoolean(R.styleable.ZoomEngine_overScrollVertical, true);
         boolean overPinchable = a.getBoolean(R.styleable.ZoomEngine_overPinchable, true);
         boolean hasChildren = a.getBoolean(R.styleable.ZoomEngine_hasClickableChildren, false);
         float minZoom = a.getFloat(R.styleable.ZoomEngine_minZoom, -1);
         float maxZoom = a.getFloat(R.styleable.ZoomEngine_maxZoom, -1);
-        @ZoomEngine.ZoomType int minZoomMode = a.getInteger(
-                R.styleable.ZoomEngine_minZoomType, ZoomEngine.TYPE_ZOOM);
-        @ZoomEngine.ZoomType int maxZoomMode = a.getInteger(
-                R.styleable.ZoomEngine_maxZoomType, ZoomEngine.TYPE_ZOOM);
+        @ZoomType int minZoomMode = a.getInteger(R.styleable.ZoomEngine_minZoomType, TYPE_ZOOM);
+        @ZoomType int maxZoomMode = a.getInteger(R.styleable.ZoomEngine_maxZoomType, TYPE_ZOOM);
+        int transformation = a.getInteger(R.styleable.ZoomEngine_transformation, TRANSFORMATION_CENTER_INSIDE);
+        int transformationGravity = a.getInt(R.styleable.ZoomEngine_transformationGravity, Gravity.CENTER);
         a.recycle();
 
         mEngine = new ZoomEngine(context, this, this);
-        mEngine.setOverScrollHorizontal(overScrollHorizontal);
-        mEngine.setOverScrollVertical(overScrollVertical);
-        mEngine.setOverPinchable(overPinchable);
-        if (minZoom > -1) mEngine.setMinZoom(minZoom, minZoomMode);
-        if (maxZoom > -1) mEngine.setMaxZoom(maxZoom, maxZoomMode);
+        setTransformation(transformation, transformationGravity);
+        setOverScrollHorizontal(overScrollHorizontal);
+        setOverScrollVertical(overScrollVertical);
+        setOverPinchable(overPinchable);
+        if (minZoom > -1) setMinZoom(minZoom, minZoomMode);
+        if (maxZoom > -1) setMaxZoom(maxZoom, maxZoomMode);
         setHasClickableChildren(hasChildren);
     }
 
@@ -253,6 +249,19 @@ public class ZoomLayout extends FrameLayout implements ZoomEngine.Listener, Zoom
     @Override
     public void setOverPinchable(boolean overPinchable) {
         getEngine().setOverPinchable(overPinchable);
+    }
+
+    /**
+     * Sets the base transformation to be applied to the content.
+     * Defaults to {@link #TRANSFORMATION_CENTER_INSIDE} with {@link Gravity#CENTER},
+     * which means that the content will be zoomed so that it fits completely inside the container.
+     *
+     * @param transformation the transformation type
+     * @param gravity        the transformation gravity. Might be ignored for some transformations
+     */
+    @Override
+    public void setTransformation(int transformation, int gravity) {
+        getEngine().setTransformation(transformation, gravity);
     }
 
     /**

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -2,7 +2,6 @@
 <resources>
     <declare-styleable name="ZoomEngine">
         <attr name="hasClickableChildren" format="boolean"/>
-        <attr name="overScrollable" format="boolean"/>
         <attr name="overScrollHorizontal" format="boolean"/>
         <attr name="overScrollVertical" format="boolean"/>
         <attr name="overPinchable" format="boolean"/>
@@ -15,6 +14,20 @@
         <attr name="maxZoomType" format="enum">
             <enum name="zoom" value="0"/>
             <enum name="realZoom" value="1"/>
+        </attr>
+        <attr name="transformation" format="enum">
+            <enum name="centerInside" value="0"/>
+            <enum name="centerCrop" value="1"/>
+            <enum name="none" value="2"/>
+        </attr>
+        <attr name="transformationGravity">
+            <flag name="top" value="0x30" />
+            <flag name="bottom" value="0x50" />
+            <flag name="left" value="0x03" />
+            <flag name="right" value="0x05" />
+            <flag name="center_vertical" value="0x10" />
+            <flag name="center_horizontal" value="0x01" />
+            <flag name="center" value="0x11" />
         </attr>
     </declare-styleable>
 


### PR DESCRIPTION
This

- Adds `setTransformation` API
- Adds `app:transformation` and `app:transformationGravity` XML attributes

Both things will control the default transformation that is applied when the content is laid out for the first time. The default value for transformation is `TRANSFORMATION_CENTER_INSIDE` and the default gravity is `Gravity.CENTER`.

- Support for `TRANSFORMATION_CENTER_CROP`
- Support for `TRANSFORMATION_NONE`
- Bump version to 1.2.0

Closes #17 