### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,8 +1,4 @@
 <manifest package="com.otaliastudios.zoom"
           xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:allowBackup="true"
-                 android:supportsRtl="true">
-    </application>
-
 </manifest>


### PR DESCRIPTION
The main objective here is to remove the allowBackup and supportsRtl tags; they were causing manifest merge errors.

But the most correct fix is to remove the application tag completely. Libraries don't need it.