### PR TITLE
Fixes view offset on Android 6 and lower

### DIFF
--- a/library/src/main/java/com/otaliastudios/zoom/ZoomLayout.java
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomLayout.java
@@ -194,7 +194,7 @@ public class ZoomLayout extends FrameLayout implements ZoomEngine.Listener, Zoom
 
         if (!mHasClickableChildren) {
             int save = canvas.save();
-            canvas.setMatrix(mMatrix);
+            canvas.concat(mMatrix);
             result = super.drawChild(canvas, child, drawingTime);
             canvas.restoreToCount(save);
         } else {


### PR DESCRIPTION
This fixes the view offset on Android 6 and lower. If the ZoomLayout has no clickable children the child is moved to the top of the screen . It seems like the views matrix is already translated in the lower versions and overriding it with a different one removes the inital translation. (Altough the views matrix says it's an identiy matrix). This behavior can be seen in the issues #32 and #22 or simply by setting the `hasClickableChildren` to false in the sample.