### PR TITLE
Feature/#66 pan while zoom

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,6 @@ android {
 }
 
 dependencies {
-    implementation "androidx.appcompat:appcompat:$supportLibVersion"
+    implementation "androidx.appcompat:appcompat:1.0.2"
     implementation project(':library')
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+
+        setProperty("archivesBaseName", "ZoomLayout_v${versionName}_(${versionCode})")
     }
 
     buildTypes {

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ allprojects {
 ext {
     // Updating? Update travis.yml.
     compileSdkVersion = 28
-    supportLibVersion = '1.0.0'
     minSdkVersion = 16
     targetSdkVersion = 28
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    api "androidx.annotation:annotation:$supportLibVersion"
+    api "androidx.annotation:annotation:1.0.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.3.1"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -33,6 +33,9 @@ android {
 dependencies {
     api "androidx.annotation:annotation:$supportLibVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.3.1"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.3.1"
 }
 
 

--- a/library/src/main/java/com/otaliastudios/zoom/AbsolutePoint.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/AbsolutePoint.kt
@@ -4,8 +4,8 @@ package com.otaliastudios.zoom
  * This class represents an absolute point on the ZoomEngine canvas (or beyond it's bounds)
  */
 data class AbsolutePoint(
-        @ZoomApi.AbsolutePan var x: Float,
-        @ZoomApi.AbsolutePan var y: Float) {
+        @ZoomApi.AbsolutePan var x: Float = 0F,
+        @ZoomApi.AbsolutePan var y: Float = 0F) {
 
     /**
      * Set new coordinates
@@ -35,6 +35,15 @@ data class AbsolutePoint(
      */
     operator fun minus(absolutePoint: AbsolutePoint): AbsolutePoint {
         return AbsolutePoint(this.x - absolutePoint.x, this.y - absolutePoint.y)
+    }
+
+    /**
+     * Negate a point
+     *
+     * @return the negative value of this point
+     */
+    operator fun unaryMinus(): AbsolutePoint {
+        return AbsolutePoint(-this.x, -this.y)
     }
 
     /**

--- a/library/src/main/java/com/otaliastudios/zoom/AbsolutePoint.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/AbsolutePoint.kt
@@ -14,9 +14,9 @@ data class AbsolutePoint(
      * @param y y-axis value
      */
     @JvmOverloads
-    fun set(@ZoomApi.AbsolutePan x: Float = this.x, @ZoomApi.AbsolutePan y: Float = this.y) {
-        this.x = x
-        this.y = y
+    fun set(@ZoomApi.AbsolutePan x: Number = this.x, @ZoomApi.AbsolutePan y: Number = this.y) {
+        this.x = x.toFloat()
+        this.y = y.toFloat()
     }
 
     /**
@@ -53,6 +53,16 @@ data class AbsolutePoint(
      */
     operator fun plus(absolutePoint: AbsolutePoint): AbsolutePoint {
         return AbsolutePoint(this.x + absolutePoint.x, this.y + absolutePoint.y)
+    }
+
+    /**
+     * Multiply every value in the point by a given factor
+     *
+     * @param factor the factor to use
+     * @return the multiplied point
+     */
+    operator fun times(factor: Number): AbsolutePoint {
+        return AbsolutePoint(factor.toFloat() * this.x, factor.toFloat() * this.y)
     }
 
 }

--- a/library/src/main/java/com/otaliastudios/zoom/AbsolutePoint.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/AbsolutePoint.kt
@@ -1,0 +1,49 @@
+package com.otaliastudios.zoom
+
+/**
+ * This class represents an absolute point on the ZoomEngine canvas (or beyond it's bounds)
+ */
+data class AbsolutePoint(
+        @ZoomApi.AbsolutePan var x: Float,
+        @ZoomApi.AbsolutePan var y: Float) {
+
+    /**
+     * Set new coordinates
+     *
+     * @param x x-axis value
+     * @param y y-axis value
+     */
+    @JvmOverloads
+    fun set(@ZoomApi.AbsolutePan x: Float = this.x, @ZoomApi.AbsolutePan y: Float = this.y) {
+        this.x = x
+        this.y = y
+    }
+
+    /**
+     * Set new coordinates
+     *
+     * @param p the [AbsolutePoint] to copy values from
+     */
+    fun set(p: AbsolutePoint) {
+        set(p.x, p.y)
+    }
+
+    /**
+     * Substract a point from another point
+     *
+     * @param absolutePoint the point to substract
+     */
+    operator fun minus(absolutePoint: AbsolutePoint): AbsolutePoint {
+        return AbsolutePoint(this.x - absolutePoint.x, this.y - absolutePoint.y)
+    }
+
+    /**
+     * Add a point to another point
+     *
+     * @param absolutePoint the point to add
+     */
+    operator fun plus(absolutePoint: AbsolutePoint): AbsolutePoint {
+        return AbsolutePoint(this.x + absolutePoint.x, this.y + absolutePoint.y)
+    }
+
+}

--- a/library/src/main/java/com/otaliastudios/zoom/AbsolutePoint.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/AbsolutePoint.kt
@@ -8,6 +8,13 @@ data class AbsolutePoint(
         @ZoomApi.AbsolutePan var y: Float = 0F) {
 
     /**
+     * Copy constructor
+     *
+     * @param point point to duplicate
+     */
+    constructor(point: AbsolutePoint) : this(point.x, point.y)
+
+    /**
      * Set new coordinates
      *
      * @param x x-axis value

--- a/library/src/main/java/com/otaliastudios/zoom/ScaledPoint.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ScaledPoint.kt
@@ -20,4 +20,43 @@ data class ScaledPoint(
         this.y += offsetY
     }
 
+    /**
+     * Set new coordinates
+     *
+     * @param x x-axis value
+     * @param y y-axis value
+     */
+    @JvmOverloads
+    fun set(@ZoomApi.ScaledPan x: Float = this.x, @ZoomApi.ScaledPan y: Float = this.y) {
+        this.x = x
+        this.y = y
+    }
+
+    /**
+     * Set new coordinates
+     *
+     * @param p the [ScaledPoint] to copy values from
+     */
+    fun set(p: ScaledPoint) {
+        set(p.x, p.y)
+    }
+
+    /**
+     * Substract a point from another point
+     *
+     * @param scaledPoint the point to substract
+     */
+    operator fun minus(scaledPoint: ScaledPoint): ScaledPoint {
+        return ScaledPoint(this.x - scaledPoint.x, this.y - scaledPoint.y)
+    }
+
+    /**
+     * Add a point to another point
+     *
+     * @param scaledPoint the point to add
+     */
+    operator fun plus(scaledPoint: ScaledPoint): ScaledPoint {
+        return ScaledPoint(this.x + scaledPoint.x, this.y + scaledPoint.y)
+    }
+
 }

--- a/library/src/main/java/com/otaliastudios/zoom/ScaledPoint.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ScaledPoint.kt
@@ -10,6 +10,13 @@ data class ScaledPoint(
         @ZoomApi.ScaledPan var y: Float = 0F) {
 
     /**
+     * Copy constructor
+     *
+     * @param point point to duplicate
+     */
+    constructor(point: ScaledPoint) : this(point.x, point.y)
+
+    /**
      * Set new coordinates
      *
      * @param x x-axis value

--- a/library/src/main/java/com/otaliastudios/zoom/ScaledPoint.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ScaledPoint.kt
@@ -1,0 +1,23 @@
+package com.otaliastudios.zoom
+
+/**
+ * This class represents a scaled point on the ZoomEngine canvas (or beyond it's bounds)
+ *
+ * Note that these values depend on the current zoomlevel
+ */
+data class ScaledPoint(
+        @ZoomApi.ScaledPan var x: Float,
+        @ZoomApi.ScaledPan var y: Float) {
+
+    /**
+     * Add the given values to this point
+     *
+     * @param x x-axis offset
+     * @param y y-axis offset
+     */
+    fun offset(@ZoomApi.ScaledPan offsetX: Float = 0F, @ZoomApi.ScaledPan offsetY: Float = 0F) {
+        this.x += offsetX
+        this.y += offsetY
+    }
+
+}

--- a/library/src/main/java/com/otaliastudios/zoom/ScaledPoint.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ScaledPoint.kt
@@ -10,26 +10,15 @@ data class ScaledPoint(
         @ZoomApi.ScaledPan var y: Float = 0F) {
 
     /**
-     * Add the given values to this point
-     *
-     * @param x x-axis offset
-     * @param y y-axis offset
-     */
-    fun offset(@ZoomApi.ScaledPan offsetX: Float = 0F, @ZoomApi.ScaledPan offsetY: Float = 0F) {
-        this.x += offsetX
-        this.y += offsetY
-    }
-
-    /**
      * Set new coordinates
      *
      * @param x x-axis value
      * @param y y-axis value
      */
     @JvmOverloads
-    fun set(@ZoomApi.ScaledPan x: Float = this.x, @ZoomApi.ScaledPan y: Float = this.y) {
-        this.x = x
-        this.y = y
+    fun set(@ZoomApi.ScaledPan x: Number = this.x, @ZoomApi.ScaledPan y: Number = this.y) {
+        this.x = x.toFloat()
+        this.y = y.toFloat()
     }
 
     /**
@@ -66,6 +55,16 @@ data class ScaledPoint(
      */
     operator fun plus(scaledPoint: ScaledPoint): ScaledPoint {
         return ScaledPoint(this.x + scaledPoint.x, this.y + scaledPoint.y)
+    }
+
+    /**
+     * Multiply every value in the point by a given factor
+     *
+     * @param factor the factor to use
+     * @return the multiplied point
+     */
+    operator fun times(factor: Number): ScaledPoint {
+        return ScaledPoint(factor.toFloat() * this.x, factor.toFloat() * this.y)
     }
 
 }

--- a/library/src/main/java/com/otaliastudios/zoom/ScaledPoint.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ScaledPoint.kt
@@ -6,8 +6,8 @@ package com.otaliastudios.zoom
  * Note that these values depend on the current zoomlevel
  */
 data class ScaledPoint(
-        @ZoomApi.ScaledPan var x: Float,
-        @ZoomApi.ScaledPan var y: Float) {
+        @ZoomApi.ScaledPan var x: Float = 0F,
+        @ZoomApi.ScaledPan var y: Float = 0F) {
 
     /**
      * Add the given values to this point
@@ -48,6 +48,15 @@ data class ScaledPoint(
      */
     operator fun minus(scaledPoint: ScaledPoint): ScaledPoint {
         return ScaledPoint(this.x - scaledPoint.x, this.y - scaledPoint.y)
+    }
+
+    /**
+     * Negate a point
+     *
+     * @return the negative value of this point
+     */
+    operator fun unaryMinus(): ScaledPoint {
+        return ScaledPoint(-this.x, -this.y)
     }
 
     /**

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
@@ -37,6 +37,13 @@ interface ZoomApi {
     @RealZoom
     val realZoom: Float
 
+
+    /**
+     * The current pan as an [AbsolutePoint].
+     * This field will be updated according to current pan when accessed.
+     */
+    val pan: AbsolutePoint
+
     /**
      * Returns the current horizontal pan value, in content coordinates
      * (that is, as if there was no zoom at all).

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
@@ -254,7 +254,7 @@ interface ZoomApi {
      * @param realZoom the new real zoom value
      * @param animate  whether to animate the transition
      */
-    fun realZoomTo(realZoom: Float, animate: Boolean)
+    fun realZoomTo(@RealZoom realZoom: Float, animate: Boolean)
 
     /**
      * Which is the max zoom that should be allowed.

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
@@ -60,6 +60,7 @@ interface ZoomApi {
      *
      * @see realZoom
      */
+    @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.LOCAL_VARIABLE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
     @Retention(AnnotationRetention.SOURCE)
     annotation class RealZoom
 
@@ -68,6 +69,7 @@ interface ZoomApi {
      *
      * @see zoom
      */
+    @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.LOCAL_VARIABLE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
     @Retention(AnnotationRetention.SOURCE)
     annotation class Zoom
 
@@ -78,6 +80,7 @@ interface ZoomApi {
      * @see panY
      * @see ScaledPan
      */
+    @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.LOCAL_VARIABLE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
     @Retention(AnnotationRetention.SOURCE)
     annotation class AbsolutePan
 
@@ -88,6 +91,7 @@ interface ZoomApi {
      * @see panY
      * @see AbsolutePan
      */
+    @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.LOCAL_VARIABLE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
     @Retention(AnnotationRetention.SOURCE)
     annotation class ScaledPan
 
@@ -97,6 +101,7 @@ interface ZoomApi {
      * @see zoom
      * @see realZoom
      */
+    @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.LOCAL_VARIABLE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(TYPE_ZOOM, TYPE_REAL_ZOOM)
     annotation class ZoomType

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -898,14 +898,15 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
          *
          * @param fixPanX the amount of pan to apply to get into a valid state (no overscroll)
          * @param fixPanY the amount of pan to apply to get into a valid state (no overscroll)
+         * @return x-axis and y-axis view coordinates
          */
         private fun calculateZoomPivotPoint(@AbsolutePan fixPanX: Float, @AbsolutePan fixPanY: Float): PointF {
             if (zoom <= 1F) {
                 // The zoom pivot point here should be based on the gravity that is used
                 // to initially transform the content.
                 // Currently this is always [View.Gravity.CENTER] as indicated by [mTransformationGravity]
-                // but this might be changed by the user
-                return PointF(mContainerWidth / 2F, mContainerHeight / 2F)
+                // but this might be changed by the user.
+                return AbsolutePoint(-mContentRect.width() / 2F, -mContentRect.height() / 2F).toViewCoordinate()
             }
 
             val x = when {

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -974,8 +974,6 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
     private inner class FlingScrollListener : GestureDetector.SimpleOnGestureListener() {
 
         override fun onDown(e: MotionEvent): Boolean {
-            // cancel any animation that might still be running
-            setState(NONE)
             return true // We are interested in the gesture.
         }
 
@@ -1225,6 +1223,7 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
         }
 
         override fun onAnimationCancel(animation: Animator?) {
+            setState(NONE)
         }
 
         override fun onAnimationRepeat(animation: Animator?) {

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -1540,7 +1540,7 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
         /**
          * The default animation duration
          */
-        const val DEFAULT_ANIMATION_DURATION: Long = 1000
+        const val DEFAULT_ANIMATION_DURATION: Long = 280
 
         private val TAG = ZoomEngine::class.java.simpleName
         private val LOG = ZoomLogger.create(TAG)

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -946,39 +946,37 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
          */
         override fun onScroll(e1: MotionEvent, e2: MotionEvent,
                               @AbsolutePan distanceX: Float, @AbsolutePan distanceY: Float): Boolean {
-            var distanceX = distanceX
-            var distanceY = distanceY
+            var delta = AbsolutePoint(distanceX, distanceY)
             if (setState(SCROLLING)) {
                 // Change sign, since we work with opposite values.
-                distanceX = -distanceX
-                distanceY = -distanceY
+                delta = -delta
 
                 // See if we are overscrolling.
                 val fixX = checkPanBounds(true, false)
                 val fixY = checkPanBounds(false, false)
 
                 // If we are overscrolling AND scrolling towards the overscroll direction...
-                if (fixX < 0 && distanceX > 0 || fixX > 0 && distanceX < 0) {
+                if (fixX < 0 && delta.x > 0 || fixX > 0 && delta.x < 0) {
                     // Compute friction: a factor for distances. Must be 1 if we are not overscrolling,
                     // and 0 if we are at the end of the available overscroll. This works:
                     val overScrollX = Math.abs(fixX) / maxOverScroll // 0 ... 1
                     val frictionX = 0.6f * (1f - Math.pow(overScrollX.toDouble(), 0.4).toFloat()) // 0 ... 0.6
                     LOG.i("onScroll", "applying friction X:", frictionX)
-                    distanceX *= frictionX
+                    delta.x *= frictionX
                 }
-                if (fixY < 0 && distanceY > 0 || fixY > 0 && distanceY < 0) {
+                if (fixY < 0 && delta.y > 0 || fixY > 0 && delta.y < 0) {
                     val overScrollY = Math.abs(fixY) / maxOverScroll // 0 ... 1
                     val frictionY = 0.6f * (1f - Math.pow(overScrollY.toDouble(), 0.4).toFloat()) // 0 ... 10.6
                     LOG.i("onScroll", "applying friction Y:", frictionY)
-                    distanceY *= frictionY
+                    delta.y *= frictionY
                 }
 
                 // If disabled, reset to 0.
-                if (!mHorizontalPanEnabled) distanceX = 0f
-                if (!mVerticalPanEnabled) distanceY = 0f
+                if (!mHorizontalPanEnabled) delta.x = 0f
+                if (!mVerticalPanEnabled) delta.y = 0f
 
-                if (distanceX != 0f || distanceY != 0f) {
-                    applyScaledPan(distanceX, distanceY, true)
+                if (delta.x != 0f || delta.y != 0f) {
+                    applyScaledPan(delta.x, delta.y, true)
                 }
                 return true
             }

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -1227,7 +1227,7 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
     }
 
     /**
-     * Prepares a [ValueAnimator] for a new run
+     * Prepares a [ValueAnimator] for the first run
      */
     private fun ValueAnimator.prepare() {
         this.duration = mAnimationDuration

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -893,11 +893,16 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
                 }
                 setState(NONE)
             } finally {
-                resetState()
+                resetPinchListenerState()
             }
         }
 
-        private fun resetState() {
+        /**
+         * Resets the fields of this pinch gesture listener
+         * to prepare it for the next pinch gesture detection
+         * and remove any remaining data from the previous gesture.
+         */
+        private fun resetPinchListenerState() {
             mInitialAbsFocusPoint.set(Float.NaN, Float.NaN)
             mCurrentAbsFocusOffset.set(0F, 0F)
         }

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -621,14 +621,13 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
         @ScaledPan val contentSize = if (horizontal) mTransformedRect.width() else mTransformedRect.height()
 
         val overScrollable = if (horizontal) mOverScrollHorizontal else mOverScrollVertical
-        @ScaledPan val overScroll = (if (overScrollable && allowOverScroll) maxOverScroll else 0).toFloat()
+        @ScaledPan val overScroll = if (overScrollable && allowOverScroll) maxOverScroll else 0
         return getPanCorrection(value, viewSize, contentSize, overScroll)
     }
 
     @ScaledPan
     private fun getPanCorrection(@ScaledPan value: Float, viewSize: Float,
-                                 @ScaledPan contentSize: Float, @ScaledPan overScroll: Float): Float {
-        @ScaledPan val tolerance = overScroll.toInt()
+                                 @ScaledPan contentSize: Float, @ScaledPan overscrollTolerance: Int): Float {
         var min: Float
         var max: Float
         if (contentSize <= viewSize) {
@@ -642,8 +641,8 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
             min = viewSize - contentSize
             max = 0f
         }
-        min -= tolerance.toFloat()
-        max += tolerance.toFloat()
+        min -= overscrollTolerance
+        max += overscrollTolerance
         var desired = value
         if (desired < min) desired = min
         if (desired > max) desired = max

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -1257,18 +1257,15 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
         if (setState(ANIMATING)) {
             mClearAnimation = false
             val startTime = System.currentTimeMillis()
-            @ScaledPan val startX = scaledPanX
-            @ScaledPan val startY = scaledPanY
-            @ScaledPan val endX = startX + deltaX
-            @ScaledPan val endY = startY + deltaY
+            val startPan = scaledPan
+            val endPan = startPan + ScaledPoint(deltaX, deltaY)
             mContainer.post(object : Runnable {
                 override fun run() {
                     if (mClearAnimation) return
                     val progress = interpolateAnimationTime(System.currentTimeMillis() - startTime)
                     LOG.v("animateScaledPan:", "animationStep:", progress)
-                    @ScaledPan val x = startX + progress * (endX - startX)
-                    @ScaledPan val y = startY + progress * (endY - startY)
-                    applyScaledPan(x - scaledPanX, y - scaledPanY, allowOverScroll)
+                    val currentPan = startPan + ((endPan - startPan) * progress) - scaledPan
+                    applyScaledPan(currentPan.x, currentPan.y, allowOverScroll)
                     if (progress >= 1f) {
                         setState(NONE)
                     } else {

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -94,7 +94,6 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
      * @see realZoom
      */
     @Zoom
-    @get:Zoom
     override var zoom = 1f // Not necessarily equal to the matrix scale.
         private set
     private var mBaseZoom = 0.toFloat() // mZoom * mBaseZoom matches the matrix scale.
@@ -138,7 +137,6 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
 
     @Zoom
     private val maxOverPinch: Float
-        @Zoom
         get() = 0.1f * (resolveZoom(mMaxZoom, mMaxZoomMode) - resolveZoom(mMinZoom, mMinZoomMode))
 
     /**
@@ -151,7 +149,6 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
      */
     @RealZoom
     override val realZoom: Float
-        @RealZoom
         get() = zoom * mBaseZoom
 
     /**
@@ -169,7 +166,6 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
      */
     @AbsolutePan
     override val panX: Float
-        @AbsolutePan
         get() = scaledPanX / realZoom
 
     /**
@@ -1252,7 +1248,7 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
      * @param deltaY          a scaled delta
      * @param allowOverScroll whether to overscroll
      */
-    private fun animateScaledPan(@ScaledPan deltaX: Float, @ScaledPan deltaY: Float,
+    private fun animateScaledPan(@AbsolutePan deltaX: Float, @ScaledPan deltaY: Float,
                                  allowOverScroll: Boolean) {
         if (setState(ANIMATING)) {
             mClearAnimation = false

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -1150,7 +1150,10 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
      * @param zoom         new zoom
      * @param x               final abs pan
      * @param y               final abs pan
-     * @param allowOverScroll whether to overscroll
+     * @param allowOverScroll true if overscroll is allowed, false otherwise
+     * @param allowOverPinch  true if overpinch is allowed, false otherwise
+     * @param zoomTargetX     the x-axis zoom target
+     * @param zoomTargetY     the y-axis zoom target
      */
     private fun animateZoomAndAbsolutePan(@Zoom zoom: Float,
                                           @AbsolutePan x: Float, @AbsolutePan y: Float,
@@ -1261,10 +1264,13 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
      * Absolute panning is achieved through [Matrix.preTranslate],
      * which works in the original coordinate system.
      *
-     * @param zoom         the new zoom value
+     * @param zoom            the new zoom value
      * @param x               the final left absolute pan
      * @param y               the final top absolute pan
-     * @param allowOverScroll whether to overscroll
+     * @param allowOverScroll true if overscroll is allowed, false otherwise
+     * @param allowOverPinch  true if overpinch is allowed, false otherwise
+     * @param zoomTargetX     the x-axis zoom target
+     * @param zoomTargetY     the y-axis zoom target
      */
     private fun applyZoomAndAbsolutePan(@Zoom zoom: Float,
                                         @AbsolutePan x: Float, @AbsolutePan y: Float,

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -1257,6 +1257,7 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
                 LOG.v("animateZoom:", "animationStep:", it.animatedFraction)
                 if (mClearAnimation) {
                     it.cancel()
+                    return@addUpdateListener
                 }
                 applyZoom(it.animatedValue as Float, allowOverPinch)
             }
@@ -1308,6 +1309,7 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
             animator.addUpdateListener {
                 if (mClearAnimation) {
                     it.cancel()
+                    return@addUpdateListener
                 }
                 val newZoom = it.getAnimatedValue("zoom") as Float
                 val currentPan = it.getAnimatedValue("pan") as AbsolutePoint
@@ -1340,6 +1342,7 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
                 LOG.v("animateScaledPan:", "animationStep:", it.animatedFraction)
                 if (mClearAnimation) {
                     it.cancel()
+                    return@addUpdateListener
                 }
                 val currentPan = it.animatedValue as ScaledPoint
                 applyScaledPan(currentPan.x, currentPan.y, allowOverScroll)

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -675,7 +675,7 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
         @ScaledPan val basePanValue = computeBasePan()[(if (horizontal) 0 else 1)]
 
         val overScrollable = if (horizontal) mOverScrollHorizontal else mOverScrollVertical
-        @ScaledPan val overScroll = if (overScrollable && allowOverScroll) maxOverScroll else 0
+        @ScaledPan val overScroll = (if (overScrollable && allowOverScroll) maxOverScroll else 0).toFloat()
         return getPanCorrection(value, viewSize, contentSize, overScroll, basePanValue)
     }
 
@@ -686,11 +686,12 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
         var min: Float
         var max: Float
         if (contentSize <= viewSize) {
-            when(mSmallerPolicy) {
+            when (mSmallerPolicy) {
                 ZoomApi.SMALLER_POLICY_FROM_TRANSFORMATION -> {
                     min = basePanValue
                     max = basePanValue
-                } else  -> {
+                }
+                else -> {
                     // If contentSize <= viewSize, we want to stay centered.
                     // Need a positive translation, that shows some background.
                     min = (viewSize - contentSize) / 2f

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -153,6 +153,12 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
         get() = zoom * mBaseZoom
 
     /**
+     * The current pan as an [AbsolutePoint]
+     */
+    private val pan: AbsolutePoint
+        get() = AbsolutePoint(panX, panY)
+
+    /**
      * Returns the current horizontal pan value, in content coordinates
      * (that is, as if there was no zoom at all) referring to what was passed
      * to [setContentSize].
@@ -174,6 +180,12 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
     @AbsolutePan
     override val panY: Float
         get() = scaledPanY / realZoom
+
+    /**
+     * The current pan as a [ScaledPoint]
+     */
+    private val scaledPan: ScaledPoint
+        get() = ScaledPoint(scaledPanX, scaledPanY)
 
     @ScaledPan
     private val scaledPanX: Float
@@ -1375,9 +1387,9 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
      * @return [AbsolutePoint]
      */
     private fun viewCoordinateToAbsolutePoint(x: Float, y: Float): AbsolutePoint {
-        val scaledPoint = ScaledPoint(-x, -y)
+        var scaledPoint = ScaledPoint(-x, -y)
         // Account for current pan.
-        scaledPoint.offset(scaledPanX, scaledPanY)
+        scaledPoint += scaledPan
         // Transform to an absolute, scale-independent value.
         return scaledPoint.toAbsolute()
     }

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -854,10 +854,6 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
                         fixPanX = unresolvePan(checkPanBounds(horizontal = true, allowOverScroll = false))
                         fixPanY = unresolvePan(checkPanBounds(horizontal = false, allowOverScroll = false))
 
-                        // recalculate pivot point based on the recalculated pan fix
-                        zoomTargetX = calculateZoomPivotPoint(true, fixPanX)
-                        zoomTargetY = calculateZoomPivotPoint(false, fixPanY)
-
                         // recalculate new pan location using the simulated target zoom level
                         newPanX = panX + fixPanX
                         newPanY = panY + fixPanY

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -1238,7 +1238,10 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
         // mMatrix.postScale(scaleFactor, scaleFactor, getScaledPanX(), getScaledPanY());
         // It keeps the pivot point at the scaled values 0, 0 (see applyPinch).
         // I think we should keep the current top, left.. Let's try:
-        mMatrix.postScale(scaleFactor, scaleFactor, 0f, 0f)
+
+//        mMatrix.postScale(scaleFactor, scaleFactor, 0f, 0f)
+        // TODO: when animating back from overpinch the content is moved to the right, why??
+        mMatrix.postScale(scaleFactor, scaleFactor, mContainerWidth / 2f, mContainerHeight / 2f)
         mMatrix.mapRect(mTransformedRect, mContentRect)
         zoom = newZoom
 

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -832,8 +832,8 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
                     }
 
                     // select zoom pivot point based on what edge of the screen is currently overscrolled
-                    var zoomTargetX = calculateZoomPivotPoint(true, fixPanX)
-                    var zoomTargetY = calculateZoomPivotPoint(false, fixPanY)
+                    val zoomTargetX = calculateZoomPivotPoint(true, fixPanX)
+                    val zoomTargetY = calculateZoomPivotPoint(false, fixPanY)
 
                     // calculate the new pan position
                     var newPanX = panX + fixPanX

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -1290,12 +1290,14 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
             LOG.i("animateZoomAndAbsolutePan:", "starting.", "startX:", startPan.x, "endX:", x, "startY:", startPan.y, "endY:", y)
             LOG.i("animateZoomAndAbsolutePan:", "starting.", "startZoom:", startZoom, "endZoom:", endZoom)
 
+            @SuppressLint("ObjectAnimatorBinding")
             val animator = ObjectAnimator.ofPropertyValuesHolder(mContainer,
                     PropertyValuesHolder.ofObject(
                             "pan",
                             TypeEvaluator { fraction: Float, startValue: AbsolutePoint, endValue: AbsolutePoint ->
                                 startValue + (endValue - startValue) * fraction
                             }, startPan, targetPan),
+
                     PropertyValuesHolder.ofFloat(
                             "zoom",
                             startZoom, endZoom)

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -841,8 +841,8 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
 
                     if (newZoom.compareTo(zoom) != 0) {
                         // we have overpinched. to calculate how much pan needs to be applied
-                        // to fix overscrolling we need to simulate the target zoom (when overpinching is fixed)
-                        // to calculate pan fix for that zoom level
+                        // to fix overscrolling we need to simulate the target zoom (when overpinching has been corrected)
+                        // to calculate the needed pan correction for that zoom level
 
                         // remember current zoom value to reset to that state later
                         val oldZoom = zoom

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -166,7 +166,7 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
      * The current pan as an [AbsolutePoint].
      * This field will be updated according to current pan when accessed.
      */
-    val pan = AbsolutePoint()
+    override val pan = AbsolutePoint()
         get() {
             field.set(panX, panY)
             return field

--- a/library/src/test/java/com/otaliastudios/zoom/AbsolutePointTest.kt
+++ b/library/src/test/java/com/otaliastudios/zoom/AbsolutePointTest.kt
@@ -4,11 +4,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class PointTests {
+class AbsolutePointTest {
 
     @Test
     fun `addition of points`() {
-        var p = AbsolutePoint(0F, 0F)
+        var p = AbsolutePoint()
         assert(p.x == 0F)
         assert(p.y == 0F)
 
@@ -25,7 +25,7 @@ class PointTests {
 
     @Test
     fun `subtraction of points`() {
-        var p = AbsolutePoint(0F, 0F)
+        var p = AbsolutePoint()
         assert(p.x == 0F)
         assert(p.y == 0F)
 
@@ -38,6 +38,26 @@ class PointTests {
 
         assert(p.x == 0F)
         assert(p.y == 0F)
+    }
+
+    @Test
+    fun `negation of a point`() {
+        var p = AbsolutePoint()
+
+        p = -p
+
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+
+        p = AbsolutePoint(1F, 1F)
+
+        assert(p.x == 1F)
+        assert(p.y == 1F)
+
+        p = -p
+
+        assert(p.x == -1F)
+        assert(p.y == -1F)
     }
 
 }

--- a/library/src/test/java/com/otaliastudios/zoom/AbsolutePointTest.kt
+++ b/library/src/test/java/com/otaliastudios/zoom/AbsolutePointTest.kt
@@ -44,6 +44,9 @@ class AbsolutePointTest {
     fun `negation of a point`() {
         var p = AbsolutePoint()
 
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+
         p = -p
 
         assert(p.x == 0F)
@@ -58,6 +61,33 @@ class AbsolutePointTest {
 
         assert(p.x == -1F)
         assert(p.y == -1F)
+    }
+
+    @Test
+    fun `multiplication of a point with a factor`() {
+        var p = AbsolutePoint()
+
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+
+        p *= 5
+
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+
+
+        p = AbsolutePoint(1F, 1F)
+        p = p * 3
+
+        assert(p.x == 3F)
+        assert(p.y == 3F)
+
+
+        p = AbsolutePoint(2F, 2F)
+        p *= 2
+
+        assert(p.x == 4F)
+        assert(p.y == 4F)
     }
 
 }

--- a/library/src/test/java/com/otaliastudios/zoom/PointTests.kt
+++ b/library/src/test/java/com/otaliastudios/zoom/PointTests.kt
@@ -1,0 +1,43 @@
+package com.otaliastudios.zoom
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PointTests {
+
+    @Test
+    fun `addition of points`() {
+        var p = AbsolutePoint(0F, 0F)
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+
+        p += AbsolutePoint(1F, 1F)
+
+        assert(p.x == 1F)
+        assert(p.y == 1F)
+
+        p += AbsolutePoint(-1F, -1F)
+
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+    }
+
+    @Test
+    fun `subtraction of points`() {
+        var p = AbsolutePoint(0F, 0F)
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+
+        p -= AbsolutePoint(1F, 1F)
+
+        assert(p.x == -1F)
+        assert(p.y == -1F)
+
+        p -= AbsolutePoint(-1F, -1F)
+
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+    }
+
+}

--- a/library/src/test/java/com/otaliastudios/zoom/ScaledPointTest.kt
+++ b/library/src/test/java/com/otaliastudios/zoom/ScaledPointTest.kt
@@ -44,6 +44,9 @@ class ScaledPointTest {
     fun `negation of a point`() {
         var p = ScaledPoint()
 
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+
         p = -p
 
         assert(p.x == 0F)
@@ -58,6 +61,33 @@ class ScaledPointTest {
 
         assert(p.x == -1F)
         assert(p.y == -1F)
+    }
+
+    @Test
+    fun `multiplication of a point with a factor`() {
+        var p = ScaledPoint()
+
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+
+        p *= 5
+
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+
+
+        p = ScaledPoint(1F, 1F)
+        p = p * 3
+
+        assert(p.x == 3F)
+        assert(p.y == 3F)
+
+
+        p = ScaledPoint(2F, 2F)
+        p *= 2
+
+        assert(p.x == 4F)
+        assert(p.y == 4F)
     }
 
 }

--- a/library/src/test/java/com/otaliastudios/zoom/ScaledPointTest.kt
+++ b/library/src/test/java/com/otaliastudios/zoom/ScaledPointTest.kt
@@ -1,0 +1,63 @@
+package com.otaliastudios.zoom
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ScaledPointTest {
+
+    @Test
+    fun `addition of points`() {
+        var p = ScaledPoint()
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+
+        p += ScaledPoint(1F, 1F)
+
+        assert(p.x == 1F)
+        assert(p.y == 1F)
+
+        p += ScaledPoint(-1F, -1F)
+
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+    }
+
+    @Test
+    fun `subtraction of points`() {
+        var p = ScaledPoint()
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+
+        p -= ScaledPoint(1F, 1F)
+
+        assert(p.x == -1F)
+        assert(p.y == -1F)
+
+        p -= ScaledPoint(-1F, -1F)
+
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+    }
+
+    @Test
+    fun `negation of a point`() {
+        var p = ScaledPoint()
+
+        p = -p
+
+        assert(p.x == 0F)
+        assert(p.y == 0F)
+
+        p = ScaledPoint(1F, 1F)
+
+        assert(p.x == 1F)
+        assert(p.y == 1F)
+
+        p = -p
+
+        assert(p.x == -1F)
+        assert(p.y == -1F)
+    }
+
+}


### PR DESCRIPTION
fixes #66 

Wow so this took quite a while for me to get it to work but I'm quite happy with the results.
The hardest part was animating back to a non-overscrolled and non-overpinched state at the same time.
I use a "simulated" zoom state to calculate the pan fixes needed to be applied to get back into a valid state when the zoom is also changing. I will add a review comment to the mentioned line, please let me know if you know a better way to do this.