### PR TITLE
added API methods: setFlingEnabled, setAllowFlingInOverscroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ In any case the current scale is not considered, so your system won't change if 
 |`setOverScrollVertical(boolean)`|If true, the content will be allowed to pan outside its vertical bounds, then return to its position.|`true`|
 |`setHorizontalPanEnabled(boolean)`|If true, the content will be allowed to pan **horizontally** by user input.|`true`|
 |`setVerticalPanEnabled(boolean)`|If true, the content will be allowed to pan **vertically** by user input.|`true`|
+|`setFlingEnabled(boolean)`|If true, fling gestures will be detected.|`true`|
+|`setAllowFlingInOverscroll(boolean)`|If true, fling gestures will be allowed even when detected while overscrolled. This might cause artifacts so it is disabled by default.|`false`|
 |`panTo(float, float, boolean)`|Pans to the given values, animating if needed.|`-`|
 |`panBy(float, float, boolean)`|Applies the given deltas to the current pan, animating if needed.|`-`|
 

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
@@ -157,6 +157,20 @@ interface ZoomApi {
     fun setZoomEnabled(enabled: Boolean)
 
     /**
+     * Controls whether fling gesture is enabled or not.
+     *
+     * @param enabled true enables fling gesture, false disables it
+     */
+    fun setFlingEnabled(enabled: Boolean)
+
+    /**
+     * Controls whether fling events are allowed when the view is in an overscrolled state.
+     *
+     * @param allow true allows fling in overscroll, false disables it
+     */
+    fun setAllowFlingInOverscroll(allow: Boolean)
+
+    /**
      * Sets the base transformation to be applied to the content.
      * Defaults to [TRANSFORMATION_CENTER_INSIDE] with [android.view.Gravity.CENTER],
      * which means that the content will be zoomed so that it fits completely inside the container.

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -378,6 +378,11 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
         mFlingEnabled = enabled
     }
 
+    /**
+     * Controls whether fling events are allowed when the view is in an overscrolled state.
+     *
+     * @param allow true allows fling in overscroll, false disables it
+     */
     override fun setAllowFlingInOverscroll(allow: Boolean) {
         mAllowFlingInOverscroll = allow
     }

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -105,6 +105,8 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
     private var mVerticalPanEnabled = true
     private var mOverPinchable = true
     private var mZoomEnabled = true
+    private var mFlingEnabled = true
+    private var mAllowFlingInOverscroll = false
     private var mClearAnimation = false
     private val mFlingScroller = OverScroller(context)
     private var mAnimationDuration = DEFAULT_ANIMATION_DURATION
@@ -365,6 +367,19 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
      */
     override fun setZoomEnabled(enabled: Boolean) {
         mZoomEnabled = enabled
+    }
+
+    /**
+     * Controls whether fling gesture is enabled or not.
+     *
+     * @param enabled true enables fling gesture, false disables it
+     */
+    override fun setFlingEnabled(enabled: Boolean) {
+        mFlingEnabled = enabled
+    }
+
+    override fun setAllowFlingInOverscroll(allow: Boolean) {
+        mAllowFlingInOverscroll = allow
     }
 
     //endregion
@@ -809,6 +824,11 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
         }
 
         override fun onFling(e1: MotionEvent, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
+            if (!mFlingEnabled) {
+                // fling is disabled, so we just ignore the event
+                return false
+            }
+
             val vX = (if (mHorizontalPanEnabled) velocityX else 0F).toInt()
             val vY = (if (mVerticalPanEnabled) velocityY else 0F).toInt()
             return startFling(vX, vY)
@@ -1316,8 +1336,8 @@ internal constructor(context: Context) : ViewTreeObserver.OnGlobalLayoutListener
         @ScaledPan val minY = mScrollerValuesY.minValue
         @ScaledPan val startY = mScrollerValuesY.startValue
         @ScaledPan val maxY = mScrollerValuesY.maxValue
-        if (mScrollerValuesX.isInOverScroll || mScrollerValuesY.isInOverScroll) {
-            // Don't accept new flings when in overscroll. This causes artifacts.
+        if (!mAllowFlingInOverscroll && (mScrollerValuesX.isInOverScroll || mScrollerValuesY.isInOverScroll)) {
+            // Only allow new flings while overscrolled if explicitly enabled as this might causes artifacts.
             return false
         }
         if (minX >= maxX && minY >= maxY && !mOverScrollVertical && !mOverScrollHorizontal) {

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomImageView.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomImageView.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Matrix
-import android.graphics.RectF
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.Gravity
@@ -46,6 +45,8 @@ private constructor(context: Context, attrs: AttributeSet?, @AttrRes defStyleAtt
         val verticalPanEnabled = a.getBoolean(R.styleable.ZoomEngine_verticalPanEnabled, true)
         val overPinchable = a.getBoolean(R.styleable.ZoomEngine_overPinchable, true)
         val zoomEnabled = a.getBoolean(R.styleable.ZoomEngine_zoomEnabled, true)
+        val flingEnabled = a.getBoolean(R.styleable.ZoomEngine_flingEnabled, true)
+        val allowFlingInOverscroll = a.getBoolean(R.styleable.ZoomEngine_allowFlingInOverscroll, true)
         val minZoom = a.getFloat(R.styleable.ZoomEngine_minZoom, -1f)
         val maxZoom = a.getFloat(R.styleable.ZoomEngine_maxZoom, -1f)
         @ZoomType val minZoomMode = a.getInteger(R.styleable.ZoomEngine_minZoomType, ZoomApi.TYPE_ZOOM)
@@ -64,6 +65,8 @@ private constructor(context: Context, attrs: AttributeSet?, @AttrRes defStyleAtt
         setVerticalPanEnabled(verticalPanEnabled)
         setOverPinchable(overPinchable)
         setZoomEnabled(zoomEnabled)
+        setFlingEnabled(flingEnabled)
+        setAllowFlingInOverscroll(allowFlingInOverscroll)
         setAnimationDuration(animationDuration)
         if (minZoom > -1) setMinZoom(minZoom, minZoomMode)
         if (maxZoom > -1) setMaxZoom(maxZoom, maxZoomMode)

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomLayout.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomLayout.kt
@@ -3,7 +3,6 @@ package com.otaliastudios.zoom
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Matrix
-import android.graphics.RectF
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.MotionEvent
@@ -51,6 +50,8 @@ private constructor(context: Context, attrs: AttributeSet?, @AttrRes defStyleAtt
         val verticalPanEnabled = a.getBoolean(R.styleable.ZoomEngine_verticalPanEnabled, true)
         val overPinchable = a.getBoolean(R.styleable.ZoomEngine_overPinchable, true)
         val zoomEnabled = a.getBoolean(R.styleable.ZoomEngine_zoomEnabled, true)
+        val flingEnabled = a.getBoolean(R.styleable.ZoomEngine_flingEnabled, true)
+        val allowFlingInOverscroll = a.getBoolean(R.styleable.ZoomEngine_allowFlingInOverscroll, true)
         val hasChildren = a.getBoolean(R.styleable.ZoomEngine_hasClickableChildren, false)
         val minZoom = a.getFloat(R.styleable.ZoomEngine_minZoom, -1f)
         val maxZoom = a.getFloat(R.styleable.ZoomEngine_maxZoom, -1f)
@@ -70,6 +71,8 @@ private constructor(context: Context, attrs: AttributeSet?, @AttrRes defStyleAtt
         setVerticalPanEnabled(verticalPanEnabled)
         setOverPinchable(overPinchable)
         setZoomEnabled(zoomEnabled)
+        setFlingEnabled(flingEnabled)
+        setAllowFlingInOverscroll(allowFlingInOverscroll)
         setAnimationDuration(animationDuration)
         if (minZoom > -1) setMinZoom(minZoom, minZoomMode)
         if (maxZoom > -1) setMaxZoom(maxZoom, maxZoomMode)

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -1,27 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="ZoomEngine">
-        <attr name="hasClickableChildren" format="boolean"/>
-        <attr name="overScrollHorizontal" format="boolean"/>
-        <attr name="overScrollVertical" format="boolean"/>
-        <attr name="overPinchable" format="boolean"/>
+        <attr name="hasClickableChildren" format="boolean" />
+        <attr name="overScrollHorizontal" format="boolean" />
+        <attr name="overScrollVertical" format="boolean" />
+        <attr name="overPinchable" format="boolean" />
         <attr name="zoomEnabled" format="boolean" />
+        <attr name="flingEnabled" format="boolean" />
+        <attr name="allowFlingInOverscroll" format="boolean" />
         <attr name="verticalPanEnabled" format="boolean" />
         <attr name="horizontalPanEnabled" format="boolean" />
-        <attr name="minZoom" format="float"/>
-        <attr name="maxZoom" format="float"/>
+        <attr name="minZoom" format="float" />
+        <attr name="maxZoom" format="float" />
         <attr name="minZoomType" format="enum">
-            <enum name="zoom" value="0"/>
-            <enum name="realZoom" value="1"/>
+            <enum name="zoom" value="0" />
+            <enum name="realZoom" value="1" />
         </attr>
         <attr name="maxZoomType" format="enum">
-            <enum name="zoom" value="0"/>
-            <enum name="realZoom" value="1"/>
+            <enum name="zoom" value="0" />
+            <enum name="realZoom" value="1" />
         </attr>
         <attr name="transformation" format="enum">
-            <enum name="centerInside" value="0"/>
-            <enum name="centerCrop" value="1"/>
-            <enum name="none" value="2"/>
+            <enum name="centerInside" value="0" />
+            <enum name="centerCrop" value="1" />
+            <enum name="none" value="2" />
         </attr>
         <attr name="transformationGravity">
             <flag name="top" value="0x30" />


### PR DESCRIPTION
fixes #69 

Thanks to @kevinadhitama for your initial work.

@natario1 I saw in the code that you had issues with some kind of artifacts when allowing fling events while overscrolled. I tested it on my device (running Android 9...) and couldn't cause any unwanted effects. To make sure the current behaviour is not changed but people who want to use it anyway (like me) can do that I added a flag and API method to change this behavior.