### PR TITLE
kotlin version bump

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ buildscript {
     extra["minSdkVersion"] = 16
     extra["compileSdkVersion"] = 29
     extra["targetSdkVersion"] = 29
-    extra["kotlinVersion"] = "1.3.61"
+    extra["kotlinVersion"] = "1.3.72"
 
     repositories {
         mavenCentral()
@@ -13,7 +13,7 @@ buildscript {
 
     dependencies {
         val kotlinVersion = property("kotlinVersion") as String
-        classpath("com.android.tools.build:gradle:3.6.1")
+        classpath("com.android.tools.build:gradle:4.0.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
         classpath("com.otaliastudios.tools:publisher:0.1.5")
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 22 13:20:40 CEST 2017
+#Thu Jun 11 11:59:19 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
bump gradle build tools version to 4.0.0
bump gradle version to 6.1.1
bump kotlin version to 1.3.72

This bump is meant to go along with Android Studio 4.0