### PR TITLE
raise an exception if a drawable without intrinsic dimensions is used

### DIFF
--- a/library/src/main/java/com/otaliastudios/zoom/ZoomImageView.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomImageView.kt
@@ -91,6 +91,9 @@ open class ZoomImageView private constructor(
 
     override fun setImageDrawable(drawable: Drawable?) {
         if (drawable != null) {
+            if (drawable.intrinsicWidth == -1 || drawable.intrinsicHeight == -1) {
+                throw IllegalArgumentException("Drawables without intrinsic dimensions (such as a solid color) are not supported")
+            }
             engine.setContentSize(drawable.intrinsicWidth.toFloat(),
                     drawable.intrinsicHeight.toFloat())
         }


### PR DESCRIPTION
Since drawables without intrinsic dimensions can not be used in the `ZoomImageView` I think it is better to raise an exception if a user tries to do just that, instead of silently "failing".