### PR TITLE
Bugfix/#152 pan to center

### DIFF
--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -76,13 +76,9 @@ internal constructor(context: Context) : ZoomApi {
 
         // Post utilities
 
-        override fun post(action: Runnable) {
-            container.post(action)
-        }
+        override fun post(action: Runnable): Boolean = container.post(action)
 
-        override fun postOnAnimation(action: Runnable) {
-            container.postOnAnimation(action)
-        }
+        override fun postOnAnimation(action: Runnable) = container.postOnAnimation(action)
 
         // Matrix callbacks
 

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -4,13 +4,16 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Matrix
 import android.graphics.RectF
-import android.view.*
+import android.view.Gravity
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewTreeObserver
 import com.otaliastudios.zoom.ZoomApi.*
-import com.otaliastudios.zoom.internal.UpdatesDispatcher
-import com.otaliastudios.zoom.internal.matrix.MatrixController
 import com.otaliastudios.zoom.internal.StateController
+import com.otaliastudios.zoom.internal.UpdatesDispatcher
 import com.otaliastudios.zoom.internal.gestures.PinchDetector
 import com.otaliastudios.zoom.internal.gestures.ScrollFlingDetector
+import com.otaliastudios.zoom.internal.matrix.MatrixController
 import com.otaliastudios.zoom.internal.matrix.MatrixUpdate
 import com.otaliastudios.zoom.internal.movement.PanManager
 import com.otaliastudios.zoom.internal.movement.ZoomManager
@@ -603,8 +606,8 @@ internal constructor(context: Context) : ZoomApi {
      * dimensions. This means applying the transformation gravity.
      */
     private fun computeTransformationPan(): ScaledPoint {
-        val extraWidth = contentWidth - containerWidth
-        val extraHeight = contentHeight - containerHeight
+        val extraWidth = contentWidth * realZoom - containerWidth
+        val extraHeight = contentHeight * realZoom - containerHeight
         val gravity = computeTransformationGravity(transformationGravity)
         val x = -panManager.applyGravity(gravity, extraWidth, true)
         val y = -panManager.applyGravity(gravity, extraHeight, false)

--- a/library/src/main/java/com/otaliastudios/zoom/internal/matrix/MatrixController.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/internal/matrix/MatrixController.kt
@@ -26,7 +26,7 @@ internal class MatrixController(
     internal interface Callback {
         fun onMatrixUpdate()
         fun onMatrixSizeChanged(oldZoom: Float, firstTime: Boolean)
-        fun post(action: Runnable)
+        fun post(action: Runnable): Boolean
         fun postOnAnimation(action: Runnable)
     }
 
@@ -151,13 +151,9 @@ internal class MatrixController(
         }
 
 
-    internal fun post(action: Runnable) {
-        callback.post(action)
-    }
+    internal fun post(action: Runnable) = callback.post(action)
 
-    internal fun postOnAnimation(action: Runnable) {
-        callback.postOnAnimation(action)
-    }
+    internal fun postOnAnimation(action: Runnable) = callback.postOnAnimation(action)
 
     /**
      * Clears our state.
@@ -213,7 +209,7 @@ internal class MatrixController(
     private fun sync() {
         stub.mapRect(contentScaledRect, contentRect)
     }
-    
+
     private fun dispatch() {
         callback.onMatrixUpdate()
     }


### PR DESCRIPTION
Honestly, I still can't quite wrap my head around how the matrix transformation stuff works, so I am not entirely sure if this is the right thing to do to fix the issue.

I tested the `ZoomImageView` on my device with different types of images of different size, and it works for all of them. I have **not** tested if code based functions like `panTo` or `moveTo` are affected by this. If I should do so please let me know.

It would probably be a good idea to add tests for these transformation functions since - at least for outside contributors - it is probably really hard to understand their intended and correct behavior, and a tiny change in code can have a massive impact on the functionality.

- Fixes #152
- Tests: *no*
- Docs updated: *no*

### Solution
As I discovered that your proposal code for centering an image in #47 did not work I found the code in `computeTransformationPan()` that did the exact same thing. Applying the `realZoom` to the content to match its `width` and `height` values with the `width` and `height` of the container fixed the issue.

Again, I don't understand every line of code in this lib yet, so, please have a thorough look and let me know if anything about this change worries you.