### PR TITLE
Bugfix/#86 cancel fling with touch

### DIFF
--- a/app/src/main/java/com/otaliastudios/zoom/demo/ColorGridView.java
+++ b/app/src/main/java/com/otaliastudios/zoom/demo/ColorGridView.java
@@ -5,15 +5,16 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.drawable.ColorDrawable;
-import androidx.annotation.AttrRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.GridLayout;
+
+import androidx.annotation.AttrRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.Random;
 
@@ -63,6 +64,13 @@ public class ColorGridView extends GridLayout {
             @Override
             public void onClick(View view) {
                 view.setBackgroundColor(Color.BLACK);
+            }
+        });
+        view.setOnLongClickListener(new OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View view) {
+                view.setBackgroundColor(Color.WHITE);
+                return true;
             }
         });
         return view;

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -159,6 +159,7 @@ internal constructor(context: Context) : ZoomApi {
     // Internal
     private lateinit var container: View
     private val callbacks = Callbacks()
+
     @Suppress("LeakingThis")
     private val dispatcher = UpdatesDispatcher(this)
     private val stateController = StateController(callbacks)
@@ -516,7 +517,7 @@ internal constructor(context: Context) : ZoomApi {
      */
     internal fun setContainer(container: View) {
         this.container = container
-        this.container.addOnAttachStateChangeListener(object: View.OnAttachStateChangeListener {
+        this.container.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
             override fun onViewAttachedToWindow(view: View) {
                 view.viewTreeObserver.addOnGlobalLayoutListener(callbacks)
             }
@@ -833,7 +834,10 @@ internal constructor(context: Context) : ZoomApi {
      * @return true if anything was cancelled, false otherwise
      */
     override fun cancelAnimations(): Boolean {
-        if (stateController.isFlinging() || stateController.isAnimating()) {
+        if (stateController.isFlinging()) {
+            scrollFlingDetector.cancelFling()
+            return true
+        } else if (stateController.isAnimating()) {
             stateController.makeIdle()
             return true
         }

--- a/library/src/main/java/com/otaliastudios/zoom/internal/StateController.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/internal/StateController.kt
@@ -66,12 +66,10 @@ internal class StateController(private val callback: Callback) {
             IDLE -> callback.onStateIdle()
         }
 
-        LOG.i("setState:", newState.toStateName())
-        state = newState
-
         // Now that it succeeded, do some cleanup.
         callback.cleanupState(oldState)
-
+        LOG.i("setState:", newState.toStateName())
+        state = newState
         return true
     }
 
@@ -97,9 +95,7 @@ internal class StateController(private val callback: Callback) {
      */
     private fun processTouchEvent(event: MotionEvent): Int {
         LOG.v("processTouchEvent:", "start.")
-        if (isAnimating()) {
-            return TOUCH_STEAL
-        }
+        if (isAnimating()) return TOUCH_STEAL
 
         var result = callback.maybeStartPinchGesture(event)
         LOG.v("processTouchEvent:", "scaleResult:", result)

--- a/library/src/main/java/com/otaliastudios/zoom/internal/StateController.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/internal/StateController.kt
@@ -3,6 +3,7 @@ package com.otaliastudios.zoom.internal
 import android.view.MotionEvent
 import androidx.annotation.IntDef
 import com.otaliastudios.zoom.ZoomLogger
+import com.otaliastudios.zoom.internal.StateController.Callback
 
 /**
  * Deals with touch input, holds the internal [state] integer,
@@ -50,6 +51,7 @@ internal class StateController(private val callback: Callback) {
     /**
      * Private function to set the current state.
      * External callers should use [setPinching], [setScrolling], [makeIdle]... instead.
+     * @return true if the new state was applied, false otherwise
      */
     private fun setState(@State newState: Int): Boolean {
         LOG.v("trySetState:", newState.toStateName())
@@ -64,10 +66,12 @@ internal class StateController(private val callback: Callback) {
             IDLE -> callback.onStateIdle()
         }
 
-        // Now that it succeeded, do some cleanup.
-        callback.cleanupState(oldState)
         LOG.i("setState:", newState.toStateName())
         state = newState
+
+        // Now that it succeeded, do some cleanup.
+        callback.cleanupState(oldState)
+
         return true
     }
 
@@ -93,7 +97,9 @@ internal class StateController(private val callback: Callback) {
      */
     private fun processTouchEvent(event: MotionEvent): Int {
         LOG.v("processTouchEvent:", "start.")
-        if (isAnimating()) return TOUCH_STEAL
+        if (isAnimating()) {
+            return TOUCH_STEAL
+        }
 
         var result = callback.maybeStartPinchGesture(event)
         LOG.v("processTouchEvent:", "scaleResult:", result)

--- a/library/src/main/java/com/otaliastudios/zoom/internal/gestures/ScrollFlingDetector.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/internal/gestures/ScrollFlingDetector.kt
@@ -118,6 +118,9 @@ internal class ScrollFlingDetector(
         }
         // Must be after the other conditions.
         if (!stateController.setFlinging()) return false
+        // disable long press detection while we are flinging
+        // to prevent long presses from interrupting a possible followup scroll gesture
+        detector.setIsLongpressEnabled(false)
 
         @ZoomApi.ScaledPan val overScrollX = if (panManager.horizontalOverPanEnabled) panManager.maxOverPan else 0F
         @ZoomApi.ScaledPan val overScrollY = if (panManager.verticalOverPanEnabled) panManager.maxOverPan else 0F
@@ -133,6 +136,8 @@ internal class ScrollFlingDetector(
             override fun run() {
                 if (flingScroller.isFinished) {
                     stateController.makeIdle()
+                    // re-enable long press detection
+                    detector.setIsLongpressEnabled(true)
                 } else if (flingScroller.computeScrollOffset()) {
                     val newPan = ScaledPoint(flingScroller.currX.toFloat(), flingScroller.currY.toFloat())
                     // OverScroller will eventually go back to our bounds.

--- a/library/src/main/java/com/otaliastudios/zoom/internal/gestures/ScrollFlingDetector.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/internal/gestures/ScrollFlingDetector.kt
@@ -65,21 +65,24 @@ internal class ScrollFlingDetector(
      * idle state.
      */
     internal fun cancelScroll() {
-        correctOverpan()
-        stateController.makeIdle()
+        if (!correctOverpan()) {
+            stateController.makeIdle()
+        }
     }
 
     /**
      * Initiates an animation to correct any existing overpan
+     * @return true if a correction was initiated, false otherwise
      */
-    private fun correctOverpan() {
+    private fun correctOverpan(): Boolean {
         if (panManager.isOverEnabled) {
             val fix = panManager.correction
             if (fix.x != 0f || fix.y != 0f) {
                 matrixController.animateUpdate { panBy(fix, true) }
-                return
+                return true
             }
         }
+        return false
     }
 
     override fun onDown(e: MotionEvent): Boolean {

--- a/library/src/main/java/com/otaliastudios/zoom/internal/gestures/ScrollFlingDetector.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/internal/gestures/ScrollFlingDetector.kt
@@ -7,8 +7,8 @@ import android.widget.OverScroller
 import com.otaliastudios.zoom.ScaledPoint
 import com.otaliastudios.zoom.ZoomApi
 import com.otaliastudios.zoom.ZoomLogger
-import com.otaliastudios.zoom.internal.matrix.MatrixController
 import com.otaliastudios.zoom.internal.StateController
+import com.otaliastudios.zoom.internal.matrix.MatrixController
 import com.otaliastudios.zoom.internal.movement.PanManager
 import kotlin.math.abs
 import kotlin.math.pow
@@ -65,6 +65,14 @@ internal class ScrollFlingDetector(
      * idle state.
      */
     internal fun cancelScroll() {
+        correctOverpan()
+        stateController.makeIdle()
+    }
+
+    /**
+     * Initiates an animation to correct any existing overpan
+     */
+    private fun correctOverpan() {
         if (panManager.isOverEnabled) {
             val fix = panManager.correction
             if (fix.x != 0f || fix.y != 0f) {
@@ -72,10 +80,10 @@ internal class ScrollFlingDetector(
                 return
             }
         }
-        stateController.makeIdle()
     }
 
     override fun onDown(e: MotionEvent): Boolean {
+        cancelFling()
         return true // We are interested in the gesture.
     }
 


### PR DESCRIPTION
- Contributes to #86 
- Tests: *no*
- Docs updated: *no*

### Solution
Any ongoing fling is now immediately interrupted if a **ACTION_DOWN** touch event is detected. If the user holds down his finger he is able to start a new scroll or fling. This is - at least for me - the behavior I expect from a f.ex. image viewer.
Since this only affects the `ScrollFlingDetector` it should not affect other ongoing animations.

This PR also adds a long click action (white tile) to the `ColorGridView`, which I needed for testing and thought it would be a useful addition, so I left it in.

It has been quite a while since I have opened #86 and sadly I am not aware anymore what the current state of the ticket is. As far as I can tell it is still **not possible** to interrupt ongoing animations using touch input. They can, however, be be interrupted by the developer when issuing a new `moveTo` or `panTo` or any similar methods, for both `animate=true` as well as `animate=false`.

The option to interrupt ongoing animations by touch is not part of this PR (except the fling of course).