### PR TITLE
Feature/#100 overzoom customization

### DIFF
--- a/docs/_docs/zoom-apis.md
+++ b/docs/_docs/zoom-apis.md
@@ -90,7 +90,11 @@ will make more sense than the other - e. g., in a PDF viewer, you might want to 
 |---|-----------|-------------|
 |`getZoom()`|Returns the current zoom, not taking into account the base scale.|`1`|
 |`getRealZoom()`|Returns the current zoom taking into account the base scale. This is the matrix scale.|`-`|
+|`getMinZoom()`|Returns the current min zoom.|`0.8`|
+|`getMinZoomType()`|Returns the current min zoom type.|`TYPE_ZOOM`|
 |`setMinZoom(float, @ZoomType int)`|Sets the lower bound when pinching out.|`0.8`, `TYPE_ZOOM`|
+|`getMaxZoom()`|Returns the current max zoom.|`2.5`|
+|`getMaxZoomType()`|Returns the current max zoom type.|`TYPE_ZOOM`|
 |`setMaxZoom(float, @ZoomType int)`|Sets the upper bound when pinching in.|`2.5`, `TYPE_REAL_ZOOM`|
 |`setOverPinchable(boolean)`|If true, the content will be allowed to zoom outside its bounds, then return to its position.|`true`|
 |`setOverZoomRange(provider)`|Sets an OverZoomRangeProvider that defines the allowed amount to zoom outside the content's bounds.|`DEFAULT_OVERZOOM_PROVIDER`|

--- a/docs/_docs/zoom-apis.md
+++ b/docs/_docs/zoom-apis.md
@@ -93,6 +93,7 @@ will make more sense than the other - e. g., in a PDF viewer, you might want to 
 |`setMinZoom(float, @ZoomType int)`|Sets the lower bound when pinching out.|`0.8`, `TYPE_ZOOM`|
 |`setMaxZoom(float, @ZoomType int)`|Sets the upper bound when pinching in.|`2.5`, `TYPE_REAL_ZOOM`|
 |`setOverPinchable(boolean)`|If true, the content will be allowed to zoom outside its bounds, then return to its position.|`true`|
+|`setOverZoomRange(provider)`|Sets an OverZoomRangeProvider that defines the allowed amount to zoom outside the content's bounds.|`DEFAULT_OVERZOOM_PROVIDER`|
 |`realZoomTo(float, boolean)`|Moves the real zoom to the given value, animating if needed.|`-`|
 |`zoomTo(float, boolean)`|Moves the zoom to the given value, animating if needed.|`-`|
 |`zoomBy(float, boolean)`|Applies the given factor to the current zoom, animating if needed. OK for both types.|`-`|

--- a/docs/_docs/zoom-apis.md
+++ b/docs/_docs/zoom-apis.md
@@ -94,6 +94,9 @@ will make more sense than the other - e. g., in a PDF viewer, you might want to 
 |`setMaxZoom(float, @ZoomType int)`|Sets the upper bound when pinching in.|`2.5`, `TYPE_REAL_ZOOM`|
 |`setOverPinchable(boolean)`|If true, the content will be allowed to zoom outside its bounds, then return to its position.|`true`|
 |`setOverZoomRange(provider)`|Sets an OverZoomRangeProvider that defines the allowed amount to zoom outside the content's bounds.|`DEFAULT_OVERZOOM_PROVIDER`|
+|`setOverScrollHorizontal(boolean)`|If true, the content will be allowed to horizontally pan outside its bounds, then return to its position.|`true`|
+|`setOverScrollVertical(boolean)`|If true, the content will be allowed to vertically pan outside its bounds, then return to its position.|`true`|
+|`setOverPanRange(provider)`|Sets an OverPanRangeProvider that defines the allowed amount to pan outside the content's bounds.|`DEFAULT_OVERPAN_PROVIDER`|
 |`realZoomTo(float, boolean)`|Moves the real zoom to the given value, animating if needed.|`-`|
 |`zoomTo(float, boolean)`|Moves the zoom to the given value, animating if needed.|`-`|
 |`zoomBy(float, boolean)`|Applies the given factor to the current zoom, animating if needed. OK for both types.|`-`|

--- a/library/src/main/java/com/otaliastudios/zoom/OverPanRangeProvider.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/OverPanRangeProvider.kt
@@ -1,0 +1,20 @@
+package com.otaliastudios.zoom
+
+/**
+ * Defines the allowed range for overpan.
+ */
+interface OverPanRangeProvider {
+
+    /**
+     * @return the maximum horizontal overpan to allow
+     */
+    @ZoomApi.ScaledPan
+    fun getHorizontalOverPanRange(engine: ZoomEngine): Float
+
+    /**
+     * @return the maximum vertical overpan to allow
+     */
+    @ZoomApi.ScaledPan
+    fun getVerticalOverPanRange(engine: ZoomEngine): Float
+
+}

--- a/library/src/main/java/com/otaliastudios/zoom/OverPanRangeProvider.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/OverPanRangeProvider.kt
@@ -6,15 +6,29 @@ package com.otaliastudios.zoom
 interface OverPanRangeProvider {
 
     /**
-     * @return the maximum horizontal overpan to allow
+     * Calculates the maximum overpan range
+     *
+     * @param engine the zoom engine
+     * @param horizontal true when horizontal range should be calculated, false for vertical
+     * @return the maximum overpan to allow
      */
     @ZoomApi.ScaledPan
-    fun getHorizontalOverPanRange(engine: ZoomEngine): Float
+    fun getOverPanRange(engine: ZoomEngine, horizontal: Boolean): Float
 
-    /**
-     * @return the maximum vertical overpan to allow
-     */
-    @ZoomApi.ScaledPan
-    fun getVerticalOverPanRange(engine: ZoomEngine): Float
+    companion object {
+        // TODO add OverScrollCallback and OverPinchCallback.
+        // Should notify the user when the boundaries are reached.
+        // TODO expose friction parameters, use an interpolator.
+        // TODO Make public, add API.
+        /**
+         * The default overscrolling factor
+         */
+        private const val DEFAULT_OVERPAN_FACTOR = 0.10f
+        val DEFAULT = object : OverPanRangeProvider {
+            override fun getOverPanRange(engine: ZoomEngine, horizontal: Boolean): Float {
+                return engine.containerHeight * DEFAULT_OVERPAN_FACTOR
+            }
+        }
+    }
 
 }

--- a/library/src/main/java/com/otaliastudios/zoom/OverPanRangeProvider.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/OverPanRangeProvider.kt
@@ -6,29 +6,30 @@ package com.otaliastudios.zoom
 interface OverPanRangeProvider {
 
     /**
-     * Calculates the maximum overpan range
+     * Calculates the maximum overpan
      *
      * @param engine the zoom engine
      * @param horizontal true when horizontal range should be calculated, false for vertical
      * @return the maximum overpan to allow
      */
     @ZoomApi.ScaledPan
-    fun getOverPanRange(engine: ZoomEngine, horizontal: Boolean): Float
+    fun getOverPan(engine: ZoomEngine, horizontal: Boolean): Float
 
     companion object {
         // TODO add OverScrollCallback and OverPinchCallback.
         // Should notify the user when the boundaries are reached.
         // TODO expose friction parameters, use an interpolator.
         // TODO Make public, add API.
-        /**
-         * The default overscrolling factor
-         */
-        private const val DEFAULT_OVERPAN_FACTOR = 0.10f
+
+        @JvmField
         val DEFAULT = object : OverPanRangeProvider {
-            override fun getOverPanRange(engine: ZoomEngine, horizontal: Boolean): Float {
-                return engine.containerHeight * DEFAULT_OVERPAN_FACTOR
+            private val DEFAULT_OVERPAN_FACTOR = 0.10f
+            override fun getOverPan(engine: ZoomEngine, horizontal: Boolean): Float {
+                return when (horizontal) {
+                    true -> engine.containerWidth * DEFAULT_OVERPAN_FACTOR
+                    false -> engine.containerHeight * DEFAULT_OVERPAN_FACTOR
+                }
             }
         }
     }
-
 }

--- a/library/src/main/java/com/otaliastudios/zoom/OverZoomRangeProvider.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/OverZoomRangeProvider.kt
@@ -16,8 +16,9 @@ interface OverZoomRangeProvider {
     fun getOverZoom(engine: ZoomEngine, inwards: Boolean): Float
 
     companion object {
-        private const val DEFAULT_OVERZOOM_FACTOR = 0.1f
+        @JvmField
         val DEFAULT = object : OverZoomRangeProvider {
+            private val DEFAULT_OVERZOOM_FACTOR = 0.1f
             override fun getOverZoom(engine: ZoomEngine, inwards: Boolean): Float {
                 return DEFAULT_OVERZOOM_FACTOR * (engine.getMaxZoom() - engine.getMinZoom())
             }

--- a/library/src/main/java/com/otaliastudios/zoom/OverZoomRangeProvider.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/OverZoomRangeProvider.kt
@@ -8,6 +8,7 @@ interface OverZoomRangeProvider {
     /**
      * @return the maximum overzoom to allow
      */
+    @ZoomApi.RealZoom
     fun getOverZoomRange(engine: ZoomEngine): Float
 
 }

--- a/library/src/main/java/com/otaliastudios/zoom/OverZoomRangeProvider.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/OverZoomRangeProvider.kt
@@ -1,0 +1,13 @@
+package com.otaliastudios.zoom
+
+/**
+ * Defines the allowed range for overzoom.
+ */
+interface OverZoomRangeProvider {
+
+    /**
+     * @return the maximum overzoom to allow
+     */
+    fun getOverZoomRange(engine: ZoomEngine): Float
+
+}

--- a/library/src/main/java/com/otaliastudios/zoom/OverZoomRangeProvider.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/OverZoomRangeProvider.kt
@@ -6,15 +6,22 @@ package com.otaliastudios.zoom
 interface OverZoomRangeProvider {
 
     /**
-     * @return the maximum inwards overzoom to allow
+     * Calculates the maximum overzoom to allow
+     *
+     * @param engine the zoom engine
+     * @param inwards true for inwards, false for outwards
+     * @return the maximum overzoom to allow
      */
     @ZoomApi.RealZoom
-    fun getOverZoomIn(engine: ZoomEngine): Float
+    fun getOverZoom(engine: ZoomEngine, inwards: Boolean): Float
 
-    /**
-     * @return the maximum outwards overzoom to allow
-     */
-    @ZoomApi.RealZoom
-    fun getOverZoomOut(engine: ZoomEngine): Float
+    companion object {
+        private const val DEFAULT_OVERZOOM_FACTOR = 0.1f
+        val DEFAULT = object : OverZoomRangeProvider {
+            override fun getOverZoom(engine: ZoomEngine, inwards: Boolean): Float {
+                return DEFAULT_OVERZOOM_FACTOR * (engine.getMaxZoom() - engine.getMinZoom())
+            }
+        }
+    }
 
 }

--- a/library/src/main/java/com/otaliastudios/zoom/OverZoomRangeProvider.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/OverZoomRangeProvider.kt
@@ -6,9 +6,15 @@ package com.otaliastudios.zoom
 interface OverZoomRangeProvider {
 
     /**
-     * @return the maximum overzoom to allow
+     * @return the maximum inwards overzoom to allow
      */
     @ZoomApi.RealZoom
-    fun getOverZoomRange(engine: ZoomEngine): Float
+    fun getOverZoomIn(engine: ZoomEngine): Float
+
+    /**
+     * @return the maximum outwards overzoom to allow
+     */
+    @ZoomApi.RealZoom
+    fun getOverZoomOut(engine: ZoomEngine): Float
 
 }

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
@@ -386,6 +386,24 @@ interface ZoomApi {
     // TODO (v2) if not removed, rename to zoomTo
 
     /**
+     * Get the currently allowed max zoom.
+     * If [ZoomApi.setOverPinchable] is set to true, this can be over-pinched
+     * for a brief time.
+     *
+     * @see zoom
+     * @see realZoom
+     */
+    fun getMaxZoom(): Float
+
+    /**
+     * Get the currently set max zoom type.
+     *
+     * @see getMaxZoom
+     */
+    @ZoomType
+    fun getMaxZoomType(): Int
+
+    /**
      * Which is the max zoom that should be allowed.
      * If [ZoomApi.setOverPinchable] is set to true, this can be over-pinched
      * for a brief time.
@@ -396,6 +414,24 @@ interface ZoomApi {
      * @see realZoom
      */
     fun setMaxZoom(maxZoom: Float, @ZoomType type: Int)
+
+    /**
+     * Get the currently allowed min zoom.
+     * If [ZoomApi.setOverPinchable] is set to true, this can be over-pinched
+     * for a brief time.
+     *
+     * @see zoom
+     * @see realZoom
+     */
+    fun getMinZoom(): Float
+
+    /**
+     * Get the currently set min zoom type.
+     *
+     * @see getMinZoom
+     */
+    @ZoomType
+    fun getMinZoomType(): Int
 
     /**
      * Which is the min zoom that should be allowed.

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
@@ -188,6 +188,12 @@ interface ZoomApi {
     // TODO (v2) rename to var isVerticalOverPanEnabled
 
     /**
+     * Set the [OverPanRangeProvider] that specifies the amount of
+     * overpan to allow.
+     */
+    fun setOverPanRange(provider: OverPanRangeProvider)
+
+    /**
      * Controls whether horizontal panning using gestures is enabled.
      *
      * @param enabled true enables horizontal panning, false disables it

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
@@ -204,6 +204,14 @@ interface ZoomApi {
     // TODO (v2) rename to var isVerticalPanEnabled
 
     /**
+     * Controls whether zoom using pinch gesture is enabled or not.
+     *
+     * @param enabled true enables zooming, false disables it
+     */
+    fun setZoomEnabled(enabled: Boolean)
+    // TODO (v2) rename to var isZoomEnabled
+
+    /**
      * Controls whether the content should be overPinchable.
      * If it is, pinch events can change the zoom outside the safe bounds,
      * than return to safe values.
@@ -214,12 +222,12 @@ interface ZoomApi {
     // TODO (v2) rename to var isOverZoomEnabled
 
     /**
-     * Controls whether zoom using pinch gesture is enabled or not.
+     * Set the [OverZoomRangeProvider] that specifies the amount of
+     * overzoom to allow.
      *
-     * @param enabled true enables zooming, false disables it
+     * @param provider the range provider
      */
-    fun setZoomEnabled(enabled: Boolean)
-    // TODO (v2) rename to var isZoomEnabled
+    fun setOverZoomRange(provider: OverZoomRangeProvider)
 
     /**
      * Controls whether fling gesture is enabled or not.

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -159,11 +159,14 @@ internal constructor(context: Context) : ZoomApi {
     // Internal
     private lateinit var container: View
     private val callbacks = Callbacks()
+
     @Suppress("LeakingThis")
     private val dispatcher = UpdatesDispatcher(this)
     private val stateController = StateController(callbacks)
     private val panManager = PanManager { matrixController }
-    private val zoomManager = ZoomManager { matrixController }
+
+    @Suppress("LeakingThis")
+    internal val zoomManager = ZoomManager(this) { matrixController }
     private val matrixController: MatrixController = MatrixController(zoomManager, panManager, stateController, callbacks)
 
     // Gestures
@@ -412,6 +415,14 @@ internal constructor(context: Context) : ZoomApi {
      */
     override fun setOverPinchable(overPinchable: Boolean) {
         zoomManager.isOverEnabled = overPinchable
+    }
+
+    /**
+     * Set the [OverZoomRangeProvider] that specifies the amount of
+     * overzoom to allow.
+     */
+    override fun setOverZoomRange(provider: OverZoomRangeProvider) {
+        zoomManager.overZoomRangeProvider = provider
     }
 
     /**

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -163,7 +163,9 @@ internal constructor(context: Context) : ZoomApi {
     @Suppress("LeakingThis")
     private val dispatcher = UpdatesDispatcher(this)
     private val stateController = StateController(callbacks)
-    private val panManager = PanManager { matrixController }
+
+    @Suppress("LeakingThis")
+    private val panManager = PanManager(this) { matrixController }
 
     @Suppress("LeakingThis")
     internal val zoomManager = ZoomManager(this) { matrixController }
@@ -386,6 +388,14 @@ internal constructor(context: Context) : ZoomApi {
      */
     override fun setOverScrollVertical(overScroll: Boolean) {
         panManager.verticalOverPanEnabled = overScroll
+    }
+
+    /**
+     * Set the [OverPanRangeProvider] that specifies the amount of
+     * overpan to allow.
+     */
+    override fun setOverPanRange(provider: OverPanRangeProvider) {
+        panManager.overPanRangeProvider = provider
     }
 
     /**

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -792,6 +792,24 @@ internal constructor(context: Context) : ZoomApi {
     }
 
     /**
+     * Get the currently allowed max zoom.
+     * If [ZoomApi.setOverPinchable] is set to true, this can be over-pinched
+     * for a brief time.
+     *
+     * @see zoom
+     * @see realZoom
+     */
+    override fun getMaxZoom(): Float  = zoomManager.maxZoom
+
+    /**
+     * Get the currently set max zoom type.
+     *
+     * @see getMaxZoom
+     */
+    @ZoomType
+    override fun getMaxZoomType(): Int = zoomManager.maxZoomMode
+
+    /**
      * Which is the max zoom that should be allowed.
      * If [setOverPinchable] is set to true, this can be over-pinched
      * for a brief time.
@@ -810,6 +828,24 @@ internal constructor(context: Context) : ZoomApi {
             realZoomTo(zoomManager.getMaxZoom(), animate = true)
         }
     }
+
+    /**
+     * Get the currently allowed min zoom.
+     * If [ZoomApi.setOverPinchable] is set to true, this can be over-pinched
+     * for a brief time.
+     *
+     * @see zoom
+     * @see realZoom
+     */
+    override fun getMinZoom(): Float  = zoomManager.minZoom
+
+    /**
+     * Get the currently set min zoom type.
+     *
+     * @see getMinZoom
+     */
+    @ZoomType
+    override fun getMinZoomType(): Int = zoomManager.minZoomMode
 
     /**
      * Which is the min zoom that should be allowed.

--- a/library/src/main/java/com/otaliastudios/zoom/internal/gestures/ScrollFlingDetector.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/internal/gestures/ScrollFlingDetector.kt
@@ -108,8 +108,8 @@ internal class ScrollFlingDetector(
         // Must be after the other conditions.
         if (!stateController.setFlinging()) return false
 
-        @ZoomApi.ScaledPan val overScrollX = if (panManager.horizontalOverPanEnabled) panManager.maxOverPan else 0F
-        @ZoomApi.ScaledPan val overScrollY = if (panManager.verticalOverPanEnabled) panManager.maxOverPan else 0F
+        @ZoomApi.ScaledPan val overScrollX = if (panManager.horizontalOverPanEnabled) panManager.maxHorizontalOverPan else 0F
+        @ZoomApi.ScaledPan val overScrollY = if (panManager.verticalOverPanEnabled) panManager.maxVerticalOverPan else 0F
         LOG.i("startFling", "velocityX:", velX, "velocityY:", velY)
         LOG.i("startFling", "flingX:", "min:", minX, "max:", maxX, "start:", startX, "overScroll:", overScrollY)
         LOG.i("startFling", "flingY:", "min:", minY, "max:", maxY, "start:", startY, "overScroll:", overScrollX)
@@ -170,13 +170,13 @@ internal class ScrollFlingDetector(
         if (panFix.x < 0 && delta.x > 0 || panFix.x > 0 && delta.x < 0) {
             // Compute friction: a factor for distances. Must be 1 if we are not overscrolling,
             // and 0 if we are at the end of the available overscroll. This works:
-            val overScrollX = abs(panFix.x) / panManager.maxOverPan // 0 ... 1
+            val overScrollX = abs(panFix.x) / panManager.maxHorizontalOverPan // 0 ... 1
             val frictionX = 0.6f * (1f - overScrollX.toDouble().pow(0.4).toFloat()) // 0 ... 0.6
             LOG.i("onScroll", "applying friction X:", frictionX)
             delta.x *= frictionX
         }
         if (panFix.y < 0 && delta.y > 0 || panFix.y > 0 && delta.y < 0) {
-            val overScrollY = abs(panFix.y) / panManager.maxOverPan // 0 ... 1
+            val overScrollY = abs(panFix.y) / panManager.maxVerticalOverPan // 0 ... 1
             val frictionY = 0.6f * (1f - overScrollY.toDouble().pow(0.4).toFloat()) // 0 ... 10.6
             LOG.i("onScroll", "applying friction Y:", frictionY)
             delta.y *= frictionY

--- a/library/src/main/java/com/otaliastudios/zoom/internal/movement/PanManager.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/internal/movement/PanManager.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.view.Gravity
 import com.otaliastudios.zoom.*
 import com.otaliastudios.zoom.internal.matrix.MatrixController
-import kotlin.math.min
 
 /**
  * Contains:
@@ -158,7 +157,7 @@ internal class PanManager(
     @ZoomApi.ScaledPan
     internal val maxHorizontalOverPan: Float
         get() {
-            var value = overPanRangeProvider.getOverPanRange(engine, horizontal = true)
+            var value = overPanRangeProvider.getOverPan(engine, horizontal = true)
             if (value < 0) {
                 LOG.w("Received negative maxHorizontalOverPan value, coercing to 0")
                 value = value.coerceAtLeast(0F)
@@ -172,7 +171,7 @@ internal class PanManager(
     @ZoomApi.ScaledPan
     internal val maxVerticalOverPan: Float
         get() {
-            var value = overPanRangeProvider.getOverPanRange(engine, horizontal = false)
+            var value = overPanRangeProvider.getOverPan(engine, horizontal = false)
             if (value < 0) {
                 LOG.w("Received negative maxVerticalOverPan value, coercing to 0")
                 value = value.coerceAtLeast(0F)

--- a/library/src/main/java/com/otaliastudios/zoom/internal/movement/ZoomManager.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/internal/movement/ZoomManager.kt
@@ -78,12 +78,20 @@ internal class ZoomManager(
     }
 
     /**
-     * The amount of overzoom that is allowed in both directions.
+     * The amount of overzoom that is allowed in inwards direction.
      * This value is calculated by the [overZoomRangeProvider].
      */
     @ZoomApi.RealZoom
-    internal val maxOverZoom: Float
-        get() = overZoomRangeProvider.getOverZoomRange(engine)
+    internal val maxOverZoomIn: Float
+        get() = overZoomRangeProvider.getOverZoomIn(engine)
+
+    /**
+     * The amount of overzoom that is allowed in outwards direction.
+     * This value is calculated by the [overZoomRangeProvider].
+     */
+    @ZoomApi.RealZoom
+    internal val maxOverZoomOut: Float
+        get() = overZoomRangeProvider.getOverZoomOut(engine)
 
     /**
      * Returns the current minimum zoom as a [ZoomApi.RealZoom] value.
@@ -121,8 +129,8 @@ internal class ZoomManager(
         var minZoom = getMinZoom()
         var maxZoom = getMaxZoom()
         if (allowOverZoom && isOverEnabled) {
-            minZoom -= maxOverZoom
-            maxZoom += maxOverZoom
+            minZoom -= maxOverZoomOut
+            maxZoom += maxOverZoomIn
         }
         return value.coerceIn(minZoom, maxZoom)
     }
@@ -130,7 +138,11 @@ internal class ZoomManager(
     companion object {
         const val DEFAULT_OVERZOOM_FACTOR = 0.1f
         val DEFAULT_OVERZOOM_PROVIDER = object : OverZoomRangeProvider {
-            override fun getOverZoomRange(engine: ZoomEngine): Float {
+            override fun getOverZoomIn(engine: ZoomEngine): Float {
+                return DEFAULT_OVERZOOM_FACTOR * (engine.getMaxZoom() - engine.getMinZoom())
+            }
+
+            override fun getOverZoomOut(engine: ZoomEngine): Float {
                 return DEFAULT_OVERZOOM_FACTOR * (engine.getMaxZoom() - engine.getMinZoom())
             }
         }

--- a/library/src/main/java/com/otaliastudios/zoom/internal/movement/ZoomManager.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/internal/movement/ZoomManager.kt
@@ -21,10 +21,10 @@ internal class ZoomManager(
 
     internal var transformationZoom = 0F
 
-    private var minZoom = ZoomApi.MIN_ZOOM_DEFAULT
-    private var minZoomMode = ZoomApi.MIN_ZOOM_DEFAULT_TYPE
-    private var maxZoom = ZoomApi.MAX_ZOOM_DEFAULT
-    private var maxZoomMode = ZoomApi.MAX_ZOOM_DEFAULT_TYPE
+    var minZoom = ZoomApi.MIN_ZOOM_DEFAULT
+    var minZoomMode = ZoomApi.MIN_ZOOM_DEFAULT_TYPE
+    var maxZoom = ZoomApi.MAX_ZOOM_DEFAULT
+    var maxZoomMode = ZoomApi.MAX_ZOOM_DEFAULT_TYPE
 
     internal var overZoomRangeProvider: OverZoomRangeProvider = DEFAULT_OVERZOOM_PROVIDER
 
@@ -131,7 +131,7 @@ internal class ZoomManager(
         const val DEFAULT_OVERZOOM_FACTOR = 0.1f
         val DEFAULT_OVERZOOM_PROVIDER = object : OverZoomRangeProvider {
             override fun getOverZoomRange(engine: ZoomEngine): Float {
-                return DEFAULT_OVERZOOM_FACTOR * (engine.zoomManager.getMaxZoom() - engine.zoomManager.getMinZoom())
+                return DEFAULT_OVERZOOM_FACTOR * (engine.getMaxZoom() - engine.getMinZoom())
             }
         }
     }


### PR DESCRIPTION
- Fixes #100
- Tests: *no*
- Docs updated: *yes*

### Solution
The overscroll and overzoom amount can now be specified using a `OverPanRangeProvider` and `OverZoomRangeProvider` respectively.

While the `OverZoomRangeProvider` has only one method that defines the range in both directions, the `OverPanRangeProvider` has two methods, one for vertical and one for the horizontal range. I think it would be a good idea to allow this separation for the zoom-in and zoom-out.

When implementing and testing, I realized that with the current implementation it would not be possible for a developer to recreate the behavior of the `DEFAULT_OVERZOOM_PROVIDER`, since there is no way for a dev to access the current `maxZoom` and `minZoom` values. It is only possible to set these, but they can not be queried, since the methods are `internal`. I am not sure how you would want to deal with this, if at all. Since these values also depend on the `ZoomType` it might be difficult to expose a single method for this.
EDIT:
I just realized you mentioned this in a comment, stating that the `maxZoom` and `minZoom` values would need public getters. I am still not sure how to deal with the zoom type though.

I am also a little bit torn about the naming. In the docs, things are called "Scroll", but in the code they are often called "Pan" instead and I am not sure if they are supposed to be the same thing or not.
