### PR TITLE
Feature/#165 move to center

### DIFF
--- a/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
@@ -311,6 +311,14 @@ interface ZoomApi {
     // TODO (v2) revisit these control APIs, possibly leveraging MatrixUpdate syntax and using AbsolutePoint
 
     /**
+     * Moves to the center of the content.
+     *
+     * @param zoom    the desired zoom value
+     * @param animate whether to animate the transition
+     */
+    fun moveToCenter(@Zoom zoom: Float? = null, animate: Boolean)
+
+    /**
      * Pans the content until the top-left coordinates match the given x-y
      * values. These are referred to the content size so they do not depend on current zoom.
      *

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -684,6 +684,16 @@ internal constructor(context: Context) : ZoomApi {
     }
 
     /**
+     * Moves to the center of the content.
+     *
+     * @param zoom    the desired zoom value
+     * @param animate whether to animate the transition
+     */
+    override fun moveToCenter(@Zoom zoom: Float?, animate: Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    /**
      * Pans the content until the top-left coordinates match the given x-y
      * values. These are referred to the content size passed in [setContentSize],
      * so they do not depend on current zoom.

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -690,7 +690,20 @@ internal constructor(context: Context) : ZoomApi {
      * @param animate whether to animate the transition
      */
     override fun moveToCenter(@Zoom zoom: Float?, animate: Boolean) {
-        TODO("Not yet implemented")
+        val targetZoom = zoom?.coerceIn(
+                zoomManager.realZoomToZoom(zoomManager.getMinZoom()),
+                zoomManager.realZoomToZoom(zoomManager.getMaxZoom())
+        ) ?: this.zoom
+        val targetRealZoom = zoomManager.zoomToRealZoom(targetZoom)
+
+        val zoomLayoutCenterX: Float = (containerWidth / targetRealZoom) / 2f
+        val zoomLayoutCenterY: Float = (containerHeight / targetRealZoom) / 2f
+        val contentCenterX: Float = contentWidth / 2f
+        val contentCenterY: Float = contentHeight / 2f
+        val diffX = (contentCenterX - zoomLayoutCenterX)
+        val diffY = (contentCenterY - zoomLayoutCenterY)
+
+        moveTo(targetZoom, -diffX, -diffY, animate)
     }
 
     /**


### PR DESCRIPTION
This adds a `moveToCenter` api method, as described in #165.

Btw, I have thought about your "recipes" idea, and - while I fully support this idea - I think, better than only writing a tutorial, is to write code in `ZoomLayout`, that actually implements these ideas, create a write-up of what the initial goal was, what the problems are and explain how the code works with a link to the actual `ZoomLayout` implementation (I mean the library here, not the class). That way the written code is always up to date, tested by actual `ZoomLayout` users, and migrated along the way as the library progresses. That way it can be used both as a functional API interface by users, as well as the code for a tutorial. Of course it has to be evaluated if a problem is worth including in the library, which is a fine.