### PR TITLE
Open constructor without container in ZoomEngine

### DIFF
--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -35,10 +35,11 @@ import kotlin.math.min
 open class ZoomEngine
 /**
  * Constructs an helper instance.
+ * The creator has to ensure that [setContainer] is called before any other operation is performed.
  *
  * @param context a valid context
  */
-internal constructor(context: Context) : ZoomApi {
+constructor(context: Context) : ZoomApi {
 
     /**
      * Constructs an helper instance.
@@ -351,6 +352,10 @@ internal constructor(context: Context) : ZoomApi {
      *
      */
     fun addListener(listener: Listener) {
+        // fail fast if the engine is not initialized properly
+        if (!::container.isInitialized) {
+            error("container is not initialized.")
+        }
         dispatcher.addListener(listener)
     }
 
@@ -531,11 +536,15 @@ internal constructor(context: Context) : ZoomApi {
 
     /**
      * Set a container to perform transformations on.
-     * This method should only be called once at initialization time.
+     * This method can only be called once at initialization time. It throws an exception if
+     * it is called twice.
      *
      * @param container view
      */
-    internal fun setContainer(container: View) {
+    fun setContainer(container: View) {
+        if(this::container.isInitialized) {
+            error("container already set")
+        }
         this.container = container
         this.container.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
             override fun onViewAttachedToWindow(view: View) {


### PR DESCRIPTION
- Fixes #190 
- Tests: no
- Docs updated: no

### Solution
I have opened the constructor and setContainer function to simplify implementation of custom views. Since the container property is a lateinit var, a readable error is already thrown when the engine would use the container:
```
    kotlin.UninitializedPropertyAccessException: lateinit property container has not been initialized
        at com.otaliastudios.zoom.ZoomEngine.access$getContainer$p(ZoomEngine.kt:35)
```

In addition I have added a check in `addListener` because without calling `addListener` you don't need an engine.
The following exception is thrown, if `setContainer` is not called and `addListener` is used:
```
     Caused by: java.lang.IllegalStateException: container is not initialized.
        at com.otaliastudios.zoom.ZoomEngine.addListener(ZoomEngine.kt:357)
```

If setContainer is called twice, an error like the following is thrown:
```
    java.lang.RuntimeException: Unable to start activity ComponentInfo{com.otaliastudios.zoom.demo/com.otaliastudios.zoom.demo.MainActivity}: android.view.InflateException: Binary XML file line #26 in com.otaliastudios.zoom.demo:layout/activity_main: Binary XML file line #26 in com.otaliastudios.zoom.demo:layout/activity_main: Error inflating class com.otaliastudios.zoom.ZoomImageView
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3449)
     ...
  Caused by: java.lang.IllegalStateException: container already set
        at com.otaliastudios.zoom.ZoomEngine.setContainer(ZoomEngine.kt:541)
        at com.otaliastudios.zoom.ZoomImageView.<init>(ZoomImageView.kt:61)
```