### PR TITLE
Fixed verbose logging via ZoomLogger

### DIFF
--- a/library/src/main/java/com/otaliastudios/zoom/ZoomLogger.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomLogger.kt
@@ -59,7 +59,7 @@ class ZoomLogger private constructor(private val mTag: String) {
     }
 
     internal fun v(vararg data: Any) {
-        i(string(LEVEL_VERBOSE, *data))
+        v(string(LEVEL_VERBOSE, *data))
     }
 
     internal fun i(vararg data: Any) {


### PR DESCRIPTION
Currently verbose logs are sent to `Log.i`, but the message validation is still based on verbose level. So:
* With `ZoomLogger.setLogLevel(ZoomLogger.LEVEL_VERBOSE)`, all the messages are there, though they are posted as info level, so it's a bit hard to make sense of my own debug logging interleaved with these.
* With `ZoomLogger.setLogLevel(ZoomLogger.LEVEL_INFO)`, there are tons of empty `I/StateController: ` in logcat.

This PR is a simple fix for the issue, calling correct `Log` method for verbose logs.
No need for tests and docs updates.