### PR TITLE
设置缩放级别时，添加参数用来控制是否需要立刻缩放控件

### DIFF
--- a/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomApi.kt
@@ -418,7 +418,7 @@ interface ZoomApi {
      *
      * @param maxZoom the max zoom
      */
-    fun setMaxZoom(@Zoom maxZoom: Float) {
+    fun setMaxZoom(@Zoom maxZoom: Float,scaleView:Boolean = true) {
         setMaxZoom(maxZoom, TYPE_ZOOM)
     }
 
@@ -432,7 +432,7 @@ interface ZoomApi {
      * @see zoom
      * @see realZoom
      */
-    fun setMaxZoom(maxZoom: Float, @ZoomType type: Int)
+    fun setMaxZoom(maxZoom: Float, @ZoomType type: Int,scaleView:Boolean = true)
 
     /**
      * Get the currently allowed min zoom.
@@ -459,7 +459,7 @@ interface ZoomApi {
      *
      * @param minZoom the min zoom
      */
-    fun setMinZoom(@Zoom minZoom: Float) {
+    fun setMinZoom(@Zoom minZoom: Float,scaleView:Boolean = true) {
         setMinZoom(minZoom, TYPE_ZOOM)
     }
 
@@ -473,7 +473,7 @@ interface ZoomApi {
      * @see zoom
      * @see realZoom
      */
-    fun setMinZoom(minZoom: Float, @ZoomType type: Int)
+    fun setMinZoom(minZoom: Float, @ZoomType type: Int,scaleView:Boolean = true)
 
     /**
      * Sets the duration of animations triggered by zoom and pan APIs.

--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -854,9 +854,9 @@ constructor(context: Context) : ZoomApi {
      *
      * @see ZoomApi.TYPE_REAL_ZOOM
      */
-    override fun setMaxZoom(maxZoom: Float, @ZoomType type: Int) {
+    override fun setMaxZoom(maxZoom: Float, @ZoomType type: Int,scaleView:Boolean) {
         zoomManager.setMaxZoom(maxZoom, type)
-        if (zoom > zoomManager.getMaxZoom()) {
+        if (zoom > zoomManager.getMaxZoom() && scaleView) {
             realZoomTo(zoomManager.getMaxZoom(), animate = true)
         }
     }
@@ -889,9 +889,9 @@ constructor(context: Context) : ZoomApi {
      * @see ZoomApi.zoom
      * @see ZoomApi.realZoom
      */
-    override fun setMinZoom(minZoom: Float, @ZoomType type: Int) {
+    override fun setMinZoom(minZoom: Float, @ZoomType type: Int,scaleView:Boolean = true) {
         zoomManager.setMinZoom(minZoom, type)
-        if (realZoom <= zoomManager.getMinZoom()) {
+        if (realZoom <= zoomManager.getMinZoom() && scaleView) {
             realZoomTo(zoomManager.getMinZoom(), animate = true)
         }
     }


### PR DESCRIPTION
我们的项目中遇到的需求，可以动态修改最大缩放级别，但是在当前源码中，修改缩放级别后，内部view会立刻执行缩放操作，因此加上参数后可以用来控制是否立刻进行缩放