### PR TITLE
Fix setMaxZoom

### DIFF
--- a/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
+++ b/library/src/main/java/com/otaliastudios/zoom/ZoomEngine.kt
@@ -856,7 +856,7 @@ constructor(context: Context) : ZoomApi {
      */
     override fun setMaxZoom(maxZoom: Float, @ZoomType type: Int) {
         zoomManager.setMaxZoom(maxZoom, type)
-        if (zoom > zoomManager.getMaxZoom()) {
+        if (realZoom > zoomManager.getMaxZoom()) {
             realZoomTo(zoomManager.getMaxZoom(), animate = true)
         }
     }


### PR DESCRIPTION
It's related to [Unwanted animated zoom after setMaxZoom call #213](https://github.com/natario1/ZoomLayout/issues/213) issue.
I tried his solution and it worked. 
I am not sure why do you use zoom instead of realZoom, but replace it by realZoom fixed the animation issue.
This PR is a simple fix.
